### PR TITLE
[Feat] 버튼 컴포넌트 개발 #14

### DIFF
--- a/.github/workflows/vercel-preview-deploy.yml
+++ b/.github/workflows/vercel-preview-deploy.yml
@@ -8,6 +8,9 @@ on:
   push:
     branches:
       - "dev"
+  pull_request:
+    branches:
+      - "dev"
 
 jobs:
   Deploy-Preview:

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,57 +1,55 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
-        default:
-          "bg-primary text-primary-foreground shadow hover:bg-primary/90",
-        destructive:
-          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
-        outline:
-          "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
-        secondary:
-          "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
+        default: "bg-gray-900 text-white text-base border-radius-lg text-base",
+        disabled: "bg-gray-100 text-gray-300 cursor-not-allowed",
+        ghost: "text-gray-200 text-[15px]", // 임시저장
+        ghost_disabled: "text-gray-700 text-[15px] cursor-not-allowed",
         link: "text-primary underline-offset-4 hover:underline",
+        card: "",
       },
       size: {
-        default: "h-9 px-4 py-2",
-        sm: "h-8 rounded-md px-3 text-xs",
-        lg: "h-10 rounded-md px-8",
-        icon: "h-9 w-9",
+        sm: "h-[36px] w-[72px]",
+        md: "h-[52px] w-[166px]",
+        lg: "h-[52px] w-[343px]",
+        icon_sm: "h-[14px] w-[14px]",
+        icon_md: "h-[18px] w-[18px]",
+        icon_lg: "h-[24px] w-[24px]",
       },
     },
     defaultVariants: {
       variant: "default",
-      size: "default",
+      size: "sm",
     },
-  }
-)
+  },
+);
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
-  asChild?: boolean
+  asChild?: boolean;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : "button"
+    const Comp = asChild ? Slot : "button";
     return (
       <Comp
         className={cn(buttonVariants({ variant, size, className }))}
         ref={ref}
         {...props}
       />
-    )
-  }
-)
-Button.displayName = "Button"
+    );
+  },
+);
+Button.displayName = "Button";
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };


### PR DESCRIPTION
### ⚾️ Related Issues
* close #14

### 📝 Task Details
* 기본 버튼(medium, large), 임시저장 버튼 개발

### 📂 References
![image](https://github.com/user-attachments/assets/14b0ec3c-b778-4ab8-9374-46278394466f)
``` javascript
   <Button variant="default" size="md">
      수정하기
   </Button>
   <Button variant="disabled" size="md">
      박스 비우기
    </Button>
    <Button variant="default" size="lg">
      선택 완료
    </Button>
    <Button variant="disabled" size="lg">
      선물 채우러 가기
    </Button>
    <Button variant="ghost" size="sm">
      임시저장
    </Button>
    <Button variant="ghost_disabled" size="sm">
      임시저장
   </Button>
```

### 💕 Review Requirements
![image](https://github.com/user-attachments/assets/a09710c6-8758-454d-81c5-ced9e9e60ec3)
링크랑 이미지 카드 제외한 기본 스타일의 버튼만 구현하여 일단 전달드립니다.. !

shadcn을 처음 사용해봐서,, 잘못 구현한 부분이 있으면 말씀주세요!
