### PR TITLE
fix: 클라이언트 사이드 훅인 useSearchParams 빌드 오류 해결

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import localFont from "next/font/local";
 import "./globals.css";
 import Header from "@/components/Header";
+import { Suspense } from "react";
 
 const pretendard = localFont({
   src: "./fonts/Pretendard.woff",
@@ -30,9 +31,11 @@ export default function RootLayout({
       <body
         className={`${pretendard.variable} ${nanumSquareRound.variable} antialiased bg-gray-100`}
       >
-        <div className="w-[375px] mx-auto bg-white min-h-full flex flex-col relative">
-          <Header/>
-        <div className="flex-grow">{children}</div>
+        <div className="w-[375px] mx-auto bg-white min-h-screen flex flex-col relative">
+          <Suspense>
+            <Header />
+          </Suspense>
+          <div className="flex-grow">{children}</div>
         </div>
       </body>
     </html>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Image from "next/image";
-import { usePathname, useRouter } from "next/navigation";
+import { useRouter, usePathname, useSearchParams } from "next/navigation";
 
 import LogoIcon from "../public/icons/logo.svg";
 import SettingIcon from "../public/icons/setting_large.svg";
@@ -20,42 +20,23 @@ const pageTitles: { [key: string]: string } = {
 const Header = () => {
   const pathname = usePathname();
   const router = useRouter();
+  const searchParams = useSearchParams();
 
   const [dynamicTitle, setDynamicTitle] = useState<string>(
     pageTitles[pathname ?? ""],
   );
 
-  const [title, setTitle] = useState<string>("");
-
-  const [searchParams, setSearchParams] = useState<URLSearchParams | null>(
-    null,
-  );
-
   const isAuthPage = ["/onboarding", "/login", "/signup"].includes(
     pathname ?? "",
   );
-
   const isHomePage = pathname === "/";
 
   useEffect(() => {
-    // 클라이언트에서만 searchParams를 사용할 수 있도록 설정
-    if (typeof window !== "undefined") {
-      const params = new URLSearchParams(window.location.search);
-      setSearchParams(params);
-    }
-  }, []);
-
-  useEffect(() => {
-    if (searchParams) {
-      setTitle(searchParams.get("title") ?? "");
+    const title = searchParams?.get("title"); // 쿼리 파라미터에서 title 가져오기
+    if (title) {
+      setDynamicTitle(title);
     }
   }, [searchParams]);
-
-  useEffect(() => {
-    if (title) {
-      setDynamicTitle(String(title));
-    }
-  }, [title]);
 
   // 메인 페이지: 로고 + 설정 아이콘
   if (isHomePage) {


### PR DESCRIPTION
### ⚾️ Related Issues
* close #[issue_number]

### 📝 Task Details
* Task 1

### 📂 References
* screenshots, GIFs, etc.

### 💕 Review Requirements
* nextjs 14 버전에서 `window.location` 보다 `useSearchParams` 훅을 사용하는 것이 더 적합한 것 같아서, [공식문서 ](https://nextjs.org/docs/app/api-reference/functions/use-search-params) 참고하여 layout 컴포넌트에서 Header 컴포넌트 <Suspense/> 로 래핑하여 렌더링되도록 수정하였습니다 !
