### PR TITLE
fix: card width 줄어듬 방지

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -5,7 +5,7 @@ import Image from "next/image";
 interface CardProps {
   img: string;
   size: "small" | "medium";
-  isActive: boolean;
+  isActive?: boolean;
   onClick: () => void;
 }
 
@@ -20,7 +20,7 @@ const Card = ({ img, size, isActive, onClick }: CardProps) => {
 
   return (
     <div
-      className={`flex justify-center border-[1.4px] items-center ${borderColorClasses} ${sizeClasses} rounded-xl box-border bg-gray-50 p-1`}
+      className={`flex justify-center border-[1.4px] items-center ${borderColorClasses} ${sizeClasses} rounded-xl box-border bg-gray-50 p-1 cursor-pointer active:border-gray-700 hover:border-gray-700`}
       onClick={onClick}
     >
       <Image

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -10,14 +10,17 @@ interface CardProps {
 }
 
 const Card = ({ img, size, isActive, onClick }: CardProps) => {
-  const sizeClasses = size === "small" ? "w-[70px] h-[70px]" : "w-22 h-22";
+  const sizeClasses =
+    size === "small"
+      ? "w-[70px] h-[70px] min-w-[70px]"
+      : "w-[88px] h-[88px] min-w-[88px]";
   const borderColorClasses = isActive ? "border-gray-700" : "border-gray-100";
 
   const imageSize = size === "small" ? 60 : 75;
 
   return (
     <div
-      className={`flex justify-center border-[1.4px] items-center ${borderColorClasses} ${sizeClasses} rounded-xl box-border bg-gray-5 p-1`}
+      className={`flex justify-center border-[1.4px] items-center ${borderColorClasses} ${sizeClasses} rounded-xl box-border bg-gray-50 p-1`}
       onClick={onClick}
     >
       <Image


### PR DESCRIPTION
### ⚾️ Related Issues
* close #[issue_number]

### 📝 Task Details
* tailwind 단위가 안먹혀서 px로 수정했습니다.
* width가 아래와 같이 부모에 맞춰서 줄어드는 현상이 있어 `min-w` 값 추가해줬습니다!
![image](https://github.com/user-attachments/assets/53b4067c-b749-4d2f-b6ee-c89daae39b33)
* card 컴포넌트에 cursor pointer 추가했구, main에서 card 컴포넌트 사용할 때 isActive가 필요하지 않을 것 같아서, 선택적 프로퍼티로 두고 active랑 hover 스타일만 일단 추가했습니다. !!


### 📂 References
* screenshots, GIFs, etc.

### 💕 Review Requirements
* Please fill out your review request.
