### PR TITLE
feat: 선물 보따리 만들기 플로우 로직 및 퍼블리싱

### DIFF
--- a/src/app/constants/constants.ts
+++ b/src/app/constants/constants.ts
@@ -2,3 +2,18 @@ export const GIFTBAG_NAME_MAX_LENGTH = 20;
 export const GIFT_NAME_MAX_LENGTH = 20;
 
 export const GIFT_SELECT_REASON_MAX_LENGTH = 100;
+
+export const REASON_CHIP_TEXTES = [
+  "직접 입력",
+  "취향 저격",
+  "실용적",
+  "특별한 의미",
+  "트렌드",
+];
+export const REASON_CHIP_MESSAGES = [
+  "",
+  "당신의 취향을 저격할 수 있는 선물일 것 같아요!",
+  "매일 쓰면서 저를 떠올려 주세요!",
+  "특별한 순간, 특별한 마음을 담아 준비했어요.",
+  "지금 가장 핫한 아이템으로 마음을 전합니다.",
+];

--- a/src/components/gift-upload/CustomTextArea.tsx
+++ b/src/components/gift-upload/CustomTextArea.tsx
@@ -1,11 +1,10 @@
-import { useState } from "react";
 import { Textarea } from "../ui/textarea";
 
 interface CustomTextAreaProps {
   placeholder: string;
   maxLength: number;
   text: string;
-  onTextChange: (text: string) => void;
+  onTextChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
 }
 
 const CustomTextArea = ({
@@ -14,22 +13,17 @@ const CustomTextArea = ({
   text,
   onTextChange,
 }: CustomTextAreaProps) => {
-  const [inputValue, setInputValue] = useState(text);
-
   return (
     <div className="relative">
       <Textarea
         placeholder={placeholder}
         className="min-h-[135px] h-[135px] resize-none bg-white placeholder:text-gray-300"
-        value={inputValue || text}
+        value={text}
         maxLength={maxLength}
-        onChange={(e) => {
-          setInputValue(e.target.value);
-          onTextChange(e.target.value);
-        }}
+        onChange={(e) => onTextChange(e)}
       />
       <span className="absolute bottom-2 right-2 text-gray-400 text-[10px]">
-        {inputValue.length} / {maxLength}
+        {text.length} / {maxLength}
       </span>
     </div>
   );

--- a/src/components/gift-upload/CustomTextArea.tsx
+++ b/src/components/gift-upload/CustomTextArea.tsx
@@ -1,10 +1,11 @@
+import { useState } from "react";
 import { Textarea } from "../ui/textarea";
 
 interface CustomTextAreaProps {
   placeholder: string;
   maxLength: number;
   text: string;
-  onTextChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  onTextChange: (text: string) => void;
 }
 
 const CustomTextArea = ({
@@ -13,17 +14,22 @@ const CustomTextArea = ({
   text,
   onTextChange,
 }: CustomTextAreaProps) => {
+  const [inputValue, setInputValue] = useState(text);
+
   return (
     <div className="relative">
       <Textarea
         placeholder={placeholder}
         className="min-h-[135px] h-[135px] resize-none bg-white placeholder:text-gray-300"
-        value={text}
-        onChange={onTextChange}
+        value={inputValue || text}
         maxLength={maxLength}
+        onChange={(e) => {
+          setInputValue(e.target.value);
+          onTextChange(e.target.value);
+        }}
       />
       <span className="absolute bottom-2 right-2 text-gray-400 text-[10px]">
-        {text.length} / {maxLength}
+        {inputValue.length} / {maxLength}
       </span>
     </div>
   );

--- a/src/components/gift-upload/GiftBoxDrawer.tsx
+++ b/src/components/gift-upload/GiftBoxDrawer.tsx
@@ -37,7 +37,13 @@ const GiftBoxDrawer = ({ handleEmptyButton, box }: GiftBoxDrawerProps) => {
           </div>
           <div>
             <p className="text-xs text-gray-300">선물을 고른 이유</p>
-            <p className="text-[15px]">{box?.reason}</p>
+            {box?.reason ? (
+              <p className="text-[15px] font-medium">{box?.reason}</p>
+            ) : (
+              <p className="text-[15px] text-gray-300 font-medium">
+                입력된 내용이 없습니다.
+              </p>
+            )}
           </div>
         </div>
         <div className="grid grid-cols-2 gap-2">

--- a/src/components/gift-upload/GiftBoxDrawer.tsx
+++ b/src/components/gift-upload/GiftBoxDrawer.tsx
@@ -1,4 +1,4 @@
-import { GiftBox } from "@/types/giftbag/types";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
   DrawerContent,
@@ -9,6 +9,7 @@ import {
 import LinkButton from "../common/LinkButton";
 import Link from "next/link";
 import { useEditBoxStore } from "@/stores/gift-upload/useStore";
+import { GiftBox } from "@/types/giftbag/types";
 
 interface GiftBoxDrawerProps {
   handleEmptyButton: () => void;
@@ -17,6 +18,12 @@ interface GiftBoxDrawerProps {
 
 const GiftBoxDrawer = ({ handleEmptyButton, box }: GiftBoxDrawerProps) => {
   const { setIsBoxEditing } = useEditBoxStore();
+  const [isConfirmingEmpty, setIsConfirmingEmpty] = useState(false);
+
+  const handleConfirmEmpty = () => {
+    handleEmptyButton();
+    setIsConfirmingEmpty(false);
+  };
 
   return (
     <DrawerContent>
@@ -25,41 +32,74 @@ const GiftBoxDrawer = ({ handleEmptyButton, box }: GiftBoxDrawerProps) => {
         <DrawerDescription />
         <p className="text-base font-medium text-center">채워진 선물 정보</p>
       </DrawerHeader>
-      <div className="flex flex-col bg-white p-6 gap-5">
-        <div>
-          <div className="h-[88px] bg-pink-100 mb-4">이미지</div>
-          <LinkButton linkUrl={box?.purchase_url || ""} />
-        </div>
-        <div className="flex flex-col gap-[27px]">
-          <div>
-            <p className="text-xs text-gray-300">선물 이름</p>
-            <p className="text-[15px]">{box?.name}</p>
-          </div>
-          <div>
-            <p className="text-xs text-gray-300">선물을 고른 이유</p>
-            {box?.reason ? (
-              <p className="text-[15px] font-medium">{box?.reason}</p>
-            ) : (
-              <p className="text-[15px] text-gray-300 font-medium">
-                입력된 내용이 없습니다.
+      <div className="flex flex-col gap-5 p-6">
+        {isConfirmingEmpty ? (
+          <div className="flex flex-col items-center justify-center gap-5">
+            <div className="mt-2 mb-5">
+              <p className="text-center text-lg font-medium">
+                박스를 정말 삭제하시겠습니까?
               </p>
-            )}
+              <p className="text-center text-sm text-gray-500">
+                삭제된 박스는 되돌릴 수 없어요.
+              </p>
+            </div>
+            <div className="flex gap-2 w-full">
+              <Button
+                className="h-[52px]"
+                variant="secondary"
+                onClick={handleConfirmEmpty}
+              >
+                박스 비우기
+              </Button>
+              <Button
+                className="h-[52px]"
+                onClick={() => setIsConfirmingEmpty(false)}
+              >
+                돌아가기
+              </Button>
+            </div>
           </div>
-        </div>
-        <div className="grid grid-cols-2 gap-2">
-          <Button
-            className="h-[52px]"
-            variant="secondary"
-            onClick={handleEmptyButton}
-          >
-            박스 비우기
-          </Button>
-          <Link href="/gift-upload">
-            <Button className="h-[52px]" onClick={() => setIsBoxEditing(true)}>
-              수정하기
-            </Button>
-          </Link>
-        </div>
+        ) : (
+          <>
+            <div>
+              <div className="h-[88px] bg-pink-100 mb-4">이미지</div>
+              <LinkButton linkUrl={box?.purchase_url || ""} />
+            </div>
+            <div className="flex flex-col gap-[27px]">
+              <div>
+                <p className="text-xs text-gray-300">선물 이름</p>
+                <p className="text-[15px]">{box?.name}</p>
+              </div>
+              <div>
+                <p className="text-xs text-gray-300">선물을 고른 이유</p>
+                {box?.reason ? (
+                  <p className="text-[15px] font-medium">{box?.reason}</p>
+                ) : (
+                  <p className="text-[15px] text-gray-300 font-medium">
+                    입력된 내용이 없습니다.
+                  </p>
+                )}
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-2">
+              <Button
+                className="h-[52px]"
+                variant="secondary"
+                onClick={() => setIsConfirmingEmpty(true)}
+              >
+                박스 비우기
+              </Button>
+              <Link href="/gift-upload">
+                <Button
+                  className="h-[52px]"
+                  onClick={() => setIsBoxEditing(true)}
+                >
+                  수정하기
+                </Button>
+              </Link>
+            </div>
+          </>
+        )}
       </div>
     </DrawerContent>
   );

--- a/src/components/gift-upload/GiftBoxDrawer.tsx
+++ b/src/components/gift-upload/GiftBoxDrawer.tsx
@@ -5,17 +5,17 @@ import LinkButton from "../common/LinkButton";
 import Link from "next/link";
 import { useEditBoxStore } from "@/stores/gift-upload/useStore";
 
-interface GiftBoxDialogProps {
+interface GiftBoxDrawerProps {
   isOpen: boolean;
   handleEmptyButton: () => void;
   box: GiftBox;
 }
 
-const GiftBoxDialog = ({
+const GiftBoxDrawer = ({
   isOpen,
   handleEmptyButton,
   box,
-}: GiftBoxDialogProps) => {
+}: GiftBoxDrawerProps) => {
   const { setIsBoxEditing } = useEditBoxStore();
 
   return (
@@ -63,4 +63,4 @@ const GiftBoxDialog = ({
   );
 };
 
-export default GiftBoxDialog;
+export default GiftBoxDrawer;

--- a/src/components/gift-upload/GiftBoxDrawer.tsx
+++ b/src/components/gift-upload/GiftBoxDrawer.tsx
@@ -1,65 +1,61 @@
 import { GiftBox } from "@/types/giftbag/types";
 import { Button } from "@/components/ui/button";
-import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from "../ui/drawer";
+import {
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+} from "../ui/drawer";
 import LinkButton from "../common/LinkButton";
 import Link from "next/link";
 import { useEditBoxStore } from "@/stores/gift-upload/useStore";
 
 interface GiftBoxDrawerProps {
-  isOpen: boolean;
   handleEmptyButton: () => void;
-  box: GiftBox;
+  box: GiftBox | null;
 }
 
-const GiftBoxDrawer = ({
-  isOpen,
-  handleEmptyButton,
-  box,
-}: GiftBoxDrawerProps) => {
+const GiftBoxDrawer = ({ handleEmptyButton, box }: GiftBoxDrawerProps) => {
   const { setIsBoxEditing } = useEditBoxStore();
 
   return (
-    <Drawer open={isOpen}>
-      <DrawerContent>
-        <DrawerHeader>
-          <DrawerTitle />
-          <p className="text-base font-medium text-center">채워진 선물 정보</p>
-        </DrawerHeader>
-        <div className="flex flex-col bg-white p-6 gap-5">
+    <DrawerContent>
+      <DrawerHeader>
+        <DrawerTitle />
+        <DrawerDescription />
+        <p className="text-base font-medium text-center">채워진 선물 정보</p>
+      </DrawerHeader>
+      <div className="flex flex-col bg-white p-6 gap-5">
+        <div>
+          <div className="h-[88px] bg-pink-100 mb-4">이미지</div>
+          <LinkButton linkUrl={box?.purchase_url || ""} />
+        </div>
+        <div className="flex flex-col gap-[27px]">
           <div>
-            <div className="h-[88px] bg-pink-100 mb-4">이미지</div>
-            <LinkButton linkUrl={box.purchase_url || ""} />
+            <p className="text-xs text-gray-300">선물 이름</p>
+            <p className="text-[15px]">{box?.name}</p>
           </div>
-          <div className="flex flex-col gap-[27px]">
-            <div>
-              <p className="text-xs text-gray-300">선물 이름</p>
-              <p className="text-[15px]">{box.name}</p>
-            </div>
-            <div>
-              <p className="text-xs text-gray-300">선물을 고른 이유</p>
-              <p className="text-[15px]">{box.reason}</p>
-            </div>
-          </div>
-          <div className="grid grid-cols-2 gap-2">
-            <Button
-              className="h-[52px]"
-              variant="secondary"
-              onClick={handleEmptyButton}
-            >
-              박스 비우기
-            </Button>
-            <Link href="/gift-upload">
-              <Button
-                className="h-[52px]"
-                onClick={() => setIsBoxEditing(true)}
-              >
-                수정하기
-              </Button>
-            </Link>
+          <div>
+            <p className="text-xs text-gray-300">선물을 고른 이유</p>
+            <p className="text-[15px]">{box?.reason}</p>
           </div>
         </div>
-      </DrawerContent>
-    </Drawer>
+        <div className="grid grid-cols-2 gap-2">
+          <Button
+            className="h-[52px]"
+            variant="secondary"
+            onClick={handleEmptyButton}
+          >
+            박스 비우기
+          </Button>
+          <Link href="/gift-upload">
+            <Button className="h-[52px]" onClick={() => setIsBoxEditing(true)}>
+              수정하기
+            </Button>
+          </Link>
+        </div>
+      </div>
+    </DrawerContent>
   );
 };
 

--- a/src/components/gift-upload/InputReason.tsx
+++ b/src/components/gift-upload/InputReason.tsx
@@ -88,7 +88,7 @@ const InputReason = ({
             <CustomTextArea
               placeholder="직접 입력해주세요."
               text={text}
-              onTextChange={(e) => onReasonChange(e.target.value)}
+              onTextChange={onReasonChange}
               maxLength={GIFT_SELECT_REASON_MAX_LENGTH}
             />
           </>

--- a/src/components/gift-upload/InputReason.tsx
+++ b/src/components/gift-upload/InputReason.tsx
@@ -13,20 +13,20 @@ import GiftIcon from "../../../public/img/gift_letter_square.svg";
 import { useGiftStore, useTagIndexStore } from "@/stores/gift-upload/useStore";
 
 interface InputReasonProps {
-  value?: string;
+  value: string;
   onReasonChange: (text: string) => void;
   onTagChange: (tag: string) => void;
   giftBoxIndex: number;
 }
 
 const InputReason = ({
-  value = "",
+  value,
   onReasonChange,
   onTagChange,
   giftBoxIndex,
 }: InputReasonProps) => {
   const { setSelectedTagIndex } = useTagIndexStore();
-  const [text, setText] = useState(value);
+  const [inputValue, setInputValue] = useState(value);
   const [tagIndex, setTagIndex] = useState(0);
 
   const { giftBoxes } = useGiftStore();
@@ -35,7 +35,7 @@ const InputReason = ({
   const selectedTagIndex = giftBoxes[giftBoxIndex].tagIndex || tagIndex;
 
   useEffect(() => {
-    setText(value);
+    setInputValue(value);
   }, [value]);
 
   useEffect(() => {
@@ -46,9 +46,15 @@ const InputReason = ({
     setTagIndex(index);
     setSelectedTagIndex(index);
     const newText = REASON_CHIP_MESSAGES[index];
-    setText(newText);
+    setInputValue(newText);
     onReasonChange(newText);
     onTagChange(REASON_CHIP_TEXTES[index]);
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const newText = e.target.value;
+    setInputValue(newText);
+    onReasonChange(newText);
   };
 
   return (
@@ -87,8 +93,8 @@ const InputReason = ({
             </div>
             <CustomTextArea
               placeholder="직접 입력해주세요."
-              text={text}
-              onTextChange={onReasonChange}
+              text={inputValue}
+              onTextChange={handleInputChange}
               maxLength={GIFT_SELECT_REASON_MAX_LENGTH}
             />
           </>

--- a/src/components/gift-upload/InputReason.tsx
+++ b/src/components/gift-upload/InputReason.tsx
@@ -25,21 +25,19 @@ const InputReason = ({
   onTagChange,
   giftBoxIndex,
 }: InputReasonProps) => {
-  const { setSelectedTagIndex } = useTagIndexStore();
+  const { selectedTagIndex, setSelectedTagIndex } = useTagIndexStore();
   const [inputValue, setInputValue] = useState(value);
-  const [tagIndex, setTagIndex] = useState(0);
 
   const { giftBoxes } = useGiftStore();
   const [isClicked, setIsClicked] = useState(giftBoxes[giftBoxIndex].filled);
-
-  const selectedTagIndex = giftBoxes[giftBoxIndex].tagIndex || tagIndex;
+  const [tagIndex, setTagIndex] = useState(giftBoxes[giftBoxIndex].tagIndex);
 
   useEffect(() => {
     setInputValue(value);
   }, [value]);
 
   useEffect(() => {
-    setSelectedTagIndex(selectedTagIndex);
+    setSelectedTagIndex(tagIndex);
   }, [tagIndex]);
 
   const handleChipClick = (index: number) => {

--- a/src/components/gift-upload/InputReason.tsx
+++ b/src/components/gift-upload/InputReason.tsx
@@ -10,7 +10,11 @@ import {
   REASON_CHIP_TEXTES,
 } from "@/app/constants/constants";
 import GiftIcon from "../../../public/img/gift_letter_square.svg";
-import { useGiftStore, useTagIndexStore } from "@/stores/gift-upload/useStore";
+import {
+  useEditBoxStore,
+  useGiftStore,
+  useTagIndexStore,
+} from "@/stores/gift-upload/useStore";
 
 interface InputReasonProps {
   value: string;
@@ -26,6 +30,7 @@ const InputReason = ({
   giftBoxIndex,
 }: InputReasonProps) => {
   const { selectedTagIndex, setSelectedTagIndex } = useTagIndexStore();
+  const { isBoxEditing } = useEditBoxStore();
   const [inputValue, setInputValue] = useState(value);
 
   const { giftBoxes } = useGiftStore();
@@ -39,6 +44,10 @@ const InputReason = ({
   useEffect(() => {
     setSelectedTagIndex(tagIndex);
   }, [tagIndex]);
+
+  useEffect(() => {
+    if (giftBoxes[giftBoxIndex].filled) setIsClicked(true);
+  }, [isBoxEditing]);
 
   const handleChipClick = (index: number) => {
     setTagIndex(index);

--- a/src/components/gift-upload/InputReason.tsx
+++ b/src/components/gift-upload/InputReason.tsx
@@ -4,18 +4,13 @@ import { useState, useEffect } from "react";
 import Image from "next/image";
 import ChipList from "./ChipList";
 import CustomTextArea from "./CustomTextArea";
-import { GIFT_SELECT_REASON_MAX_LENGTH } from "@/app/constants/constants";
+import {
+  GIFT_SELECT_REASON_MAX_LENGTH,
+  REASON_CHIP_MESSAGES,
+  REASON_CHIP_TEXTES,
+} from "@/app/constants/constants";
 import GiftIcon from "../../../public/img/gift_letter_square.svg";
 import { useGiftStore, useTagIndexStore } from "@/stores/gift-upload/useStore";
-
-const chipText = ["직접 입력", "취향 저격", "실용적", "특별한 의미", "트렌드"];
-const chipMessages = [
-  "",
-  "당신의 취향을 저격할 수 있는 선물일 것 같아요!",
-  "매일 쓰면서 저를 떠올려 주세요!",
-  "특별한 순간, 특별한 마음을 담아 준비했어요.",
-  "지금 가장 핫한 아이템으로 마음을 전합니다.",
-];
 
 interface InputReasonProps {
   value?: string;
@@ -50,10 +45,10 @@ const InputReason = ({
   const handleChipClick = (index: number) => {
     setTagIndex(index);
     setSelectedTagIndex(index);
-    const newText = chipMessages[index];
+    const newText = REASON_CHIP_MESSAGES[index];
     setText(newText);
     onReasonChange(newText);
-    onTagChange(chipText[index]);
+    onTagChange(REASON_CHIP_TEXTES[index]);
   };
 
   return (
@@ -84,7 +79,7 @@ const InputReason = ({
             >
               <div className="min-w-max">
                 <ChipList
-                  chipText={chipText}
+                  chipText={REASON_CHIP_TEXTES}
                   selectedChipIndex={selectedTagIndex}
                   onChipClick={handleChipClick}
                 />

--- a/src/components/gift-upload/InputReason.tsx
+++ b/src/components/gift-upload/InputReason.tsx
@@ -25,12 +25,12 @@ const InputReason = ({
   onTagChange,
   giftBoxIndex,
 }: InputReasonProps) => {
-  const [isClicked, setIsClicked] = useState(false);
   const { setSelectedTagIndex } = useTagIndexStore();
   const [text, setText] = useState(value);
   const [tagIndex, setTagIndex] = useState(0);
 
   const { giftBoxes } = useGiftStore();
+  const [isClicked, setIsClicked] = useState(giftBoxes[giftBoxIndex].filled);
 
   const selectedTagIndex = giftBoxes[giftBoxIndex].tagIndex || tagIndex;
 

--- a/src/components/gift-upload/InputReason.tsx
+++ b/src/components/gift-upload/InputReason.tsx
@@ -49,6 +49,14 @@ const InputReason = ({
     if (giftBoxes[giftBoxIndex].filled) setIsClicked(true);
   }, [isBoxEditing]);
 
+  useEffect(() => {
+    if (isBoxEditing) {
+      const currentTagIndex = giftBoxes[giftBoxIndex].tagIndex;
+      setTagIndex(currentTagIndex);
+      setSelectedTagIndex(currentTagIndex);
+    }
+  }, [isBoxEditing, giftBoxIndex, giftBoxes]);
+
   const handleChipClick = (index: number) => {
     setTagIndex(index);
     setSelectedTagIndex(index);

--- a/src/components/giftbag/GiftList.tsx
+++ b/src/components/giftbag/GiftList.tsx
@@ -94,16 +94,9 @@ const GiftList = ({ value }: GiftListProps) => {
                       router.push(`/gift-upload?index=${index}`);
                     }}
                   >
-                    <Image
-                      src={imageSrc}
-                      alt={`gift-item-${index}`}
-                      className="w-full h-full object-contain hover:opacity-[75%]"
-                      width="110"
-                      height="110"
-                    />
-                    {index === 0 && (
+                    {index === 0 ? (
                       <Tooltip>
-                        <TooltipTrigger>
+                        <TooltipTrigger asChild>
                           <Image
                             src={DEFAULT_IMAGES[index % 2]}
                             alt={`gift-item-${index}`}
@@ -112,10 +105,22 @@ const GiftList = ({ value }: GiftListProps) => {
                             height="110"
                           />
                         </TooltipTrigger>
-                        <TooltipContent side="bottom" align="center">
+                        <TooltipContent
+                          side="bottom"
+                          align="center"
+                          className="bg-white text-black font-nanum -mt-1"
+                        >
                           사진으로 간단하게 <br /> 선물박스를 채워볼까요?
                         </TooltipContent>
                       </Tooltip>
+                    ) : (
+                      <Image
+                        src={imageSrc}
+                        alt={`gift-item-${index}`}
+                        className="w-full h-full object-contain hover:opacity-[75%]"
+                        width="110"
+                        height="110"
+                      />
                     )}
                   </div>
                 )}

--- a/src/components/giftbag/GiftList.tsx
+++ b/src/components/giftbag/GiftList.tsx
@@ -10,6 +10,7 @@ import {
 import { GiftBox } from "@/types/giftbag/types";
 import { useGiftStore } from "@/stores/gift-upload/useStore";
 import GiftBoxDrawer from "../gift-upload/GiftBoxDrawer";
+import { Drawer, DrawerTrigger } from "../ui/drawer";
 
 const DEFAULT_IMAGES = [
   "/img/gift_blank_square.svg",
@@ -28,31 +29,21 @@ interface GiftListProps {
 const GiftList = ({ value }: GiftListProps) => {
   const router = useRouter();
   const [selectedBox, setSelectedBox] = useState<GiftBox | null>(null);
-  const [isDialogOpen, setIsDialogOpen] = useState(false);
 
   const { giftBoxes, updateGiftBox } = useGiftStore();
 
-  const openDialog = (box: GiftBox) => {
-    setSelectedBox(box);
-    setIsDialogOpen(true);
-  };
-
   const emptyGiftBox = () => {
-    if (selectedBox) {
-      const index = giftBoxes.findIndex((box) => box === selectedBox);
+    const index = giftBoxes.findIndex((box) => box === selectedBox);
 
-      if (index !== -1) {
-        updateGiftBox(index, {
-          name: "",
-          reason: "",
-          purchase_url: "",
-          tag: "",
-          filled: false,
-        });
-      }
+    if (index !== -1) {
+      updateGiftBox(index, {
+        name: "",
+        reason: "",
+        purchase_url: "",
+        tag: "",
+        filled: false,
+      });
     }
-
-    setIsDialogOpen(false);
     setSelectedBox(null);
   };
 
@@ -70,52 +61,75 @@ const GiftList = ({ value }: GiftListProps) => {
               : DEFAULT_IMAGES[index % 2];
 
             return (
-              <div
-                key={index}
-                className="w-[130px] h-[130px] p-[10px] flex justify-center items-center cursor-pointer transition-opacity duration-500 ease-in-out"
-                onClick={() => {
-                  if (box.filled) {
-                    openDialog(box);
-                  } else {
-                    router.push(`/gift-upload?index=${index}`);
-                  }
-                }}
-              >
-                <Image
-                  src={imageSrc}
-                  alt={`gift-item-${index}`}
-                  className="w-full h-full object-contain hover:opacity-[75%]"
-                  width="110"
-                  height="110"
-                />
-                {index === 0 && !box.filled && (
-                  <Tooltip>
-                    <TooltipTrigger>
-                      <Image
-                        src={DEFAULT_IMAGES[index % 2]}
-                        alt={`gift-item-${index}`}
-                        className="w-full h-full object-contain hover:opacity-[75%]"
-                        width="110"
-                        height="110"
-                      />
-                    </TooltipTrigger>
-                    <TooltipContent side="top" align="center">
-                      사진으로 간단하게 <br /> 선물박스를 채워볼까요?
-                    </TooltipContent>
-                  </Tooltip>
+              <Drawer key={index}>
+                {box.filled ? (
+                  <>
+                    <DrawerTrigger>
+                      <div
+                        key={index}
+                        className="w-[130px] h-[130px] p-[10px] flex justify-center items-center cursor-pointer transition-opacity duration-500 ease-in-out"
+                        onClick={() => {
+                          if (!box.filled) {
+                            router.push(`/gift-upload?index=${index}`);
+                          } else {
+                            setSelectedBox(box);
+                          }
+                        }}
+                      >
+                        <Image
+                          src={imageSrc}
+                          alt={`gift-item-${index}`}
+                          className="w-full h-full object-contain hover:opacity-[75%]"
+                          width="110"
+                          height="110"
+                        />
+                      </div>
+                    </DrawerTrigger>
+                    <GiftBoxDrawer
+                      handleEmptyButton={emptyGiftBox}
+                      box={selectedBox}
+                    />
+                  </>
+                ) : (
+                  <div
+                    key={index}
+                    className="w-[130px] h-[130px] p-[10px] flex justify-center items-center cursor-pointer transition-opacity duration-500 ease-in-out"
+                    onClick={() => {
+                      if (!box.filled) {
+                        router.push(`/gift-upload?index=${index}`);
+                      }
+                    }}
+                  >
+                    <Image
+                      src={imageSrc}
+                      alt={`gift-item-${index}`}
+                      className="w-full h-full object-contain hover:opacity-[75%]"
+                      width="110"
+                      height="110"
+                    />
+                    {index === 0 && (
+                      <Tooltip>
+                        <TooltipTrigger>
+                          <Image
+                            src={DEFAULT_IMAGES[index % 2]}
+                            alt={`gift-item-${index}`}
+                            className="w-full h-full object-contain hover:opacity-[75%]"
+                            width="110"
+                            height="110"
+                          />
+                        </TooltipTrigger>
+                        <TooltipContent side="top" align="center">
+                          사진으로 간단하게 <br /> 선물박스를 채워볼까요?
+                        </TooltipContent>
+                      </Tooltip>
+                    )}
+                  </div>
                 )}
-              </div>
+              </Drawer>
             );
           })}
         </div>
       </TooltipProvider>
-      {selectedBox && (
-        <GiftBoxDrawer
-          isOpen={isDialogOpen}
-          handleEmptyButton={emptyGiftBox}
-          box={selectedBox}
-        />
-      )}
     </>
   );
 };

--- a/src/components/giftbag/GiftList.tsx
+++ b/src/components/giftbag/GiftList.tsx
@@ -8,8 +8,8 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { GiftBox } from "@/types/giftbag/types";
-import GiftBoxDialog from "../gift-upload/GiftBoxDialog";
 import { useGiftStore } from "@/stores/gift-upload/useStore";
+import GiftBoxDrawer from "../gift-upload/GiftBoxDrawer";
 
 const DEFAULT_IMAGES = [
   "/img/gift_blank_square.svg",
@@ -110,7 +110,7 @@ const GiftList = ({ value }: GiftListProps) => {
         </div>
       </TooltipProvider>
       {selectedBox && (
-        <GiftBoxDialog
+        <GiftBoxDrawer
           isOpen={isDialogOpen}
           handleEmptyButton={emptyGiftBox}
           box={selectedBox}

--- a/src/components/giftbag/GiftList.tsx
+++ b/src/components/giftbag/GiftList.tsx
@@ -91,9 +91,7 @@ const GiftList = ({ value }: GiftListProps) => {
                     key={index}
                     className="w-[130px] h-[130px] p-[10px] flex justify-center items-center cursor-pointer transition-opacity duration-500 ease-in-out"
                     onClick={() => {
-                      if (!box.filled) {
-                        router.push(`/gift-upload?index=${index}`);
-                      }
+                      router.push(`/gift-upload?index=${index}`);
                     }}
                   >
                     <Image
@@ -114,7 +112,7 @@ const GiftList = ({ value }: GiftListProps) => {
                             height="110"
                           />
                         </TooltipTrigger>
-                        <TooltipContent side="top" align="center">
+                        <TooltipContent side="bottom" align="center">
                           사진으로 간단하게 <br /> 선물박스를 채워볼까요?
                         </TooltipContent>
                       </Tooltip>

--- a/src/components/giftbag/GiftList.tsx
+++ b/src/components/giftbag/GiftList.tsx
@@ -69,11 +69,7 @@ const GiftList = ({ value }: GiftListProps) => {
                         key={index}
                         className="w-[130px] h-[130px] p-[10px] flex justify-center items-center cursor-pointer transition-opacity duration-500 ease-in-out"
                         onClick={() => {
-                          if (!box.filled) {
-                            router.push(`/gift-upload?index=${index}`);
-                          } else {
-                            setSelectedBox(box);
-                          }
+                          setSelectedBox(box);
                         }}
                       >
                         <Image

--- a/src/components/giftbag/SelectedGiftBag.tsx
+++ b/src/components/giftbag/SelectedGiftBag.tsx
@@ -2,9 +2,12 @@
 
 import { useStore } from "@/stores/giftbag/useStore";
 import Image from "next/image";
+import { useEffect, useState } from "react";
 
 const SelectedGiftBag = () => {
   const { selectedBagIndex } = useStore();
+  const [hydrated, setHydrated] = useState(false);
+
   const imagePaths = [
     "/img/giftBag_red.svg",
     "/img/giftBag_pink.svg",
@@ -12,6 +15,18 @@ const SelectedGiftBag = () => {
     "/img/giftBag_yellow.svg",
     "/img/giftBag_green.svg",
   ];
+
+  useEffect(() => {
+    setHydrated(true);
+  }, []);
+
+  if (!hydrated) {
+    return (
+      <div className="w-[260px] h-[260px] flex items-center justify-center mt-10">
+        <div className="w-12 h-12 border-4 border-pink-300 border-t-transparent rounded-full animate-spin"></div>
+      </div>
+    );
+  }
 
   return (
     <div className="w-[260px] h-[260px] mt-10 py-4 px-7">

--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -7,6 +7,7 @@ import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import LogoIcon from "../../public/icons/logo.svg";
 import SettingIcon from "../../public/icons/setting_large.svg";
 import ArrowLeftIcon from "../../public/icons/arrow_left_large.svg";
+import { useEditBoxStore } from "@/stores/gift-upload/useStore";
 
 // 정적 title 관리
 // 임시 매핑
@@ -33,6 +34,9 @@ const Header = () => {
   const isNotFoundPage = !Object.keys(pageTitles).some((key) =>
     pathname?.startsWith(key),
   );
+  const isGiftUploadPage = pathname === "/gift-upload";
+
+  const { setIsBoxEditing } = useEditBoxStore();
 
   useEffect(() => {
     const title = searchParams?.get("title"); // 쿼리 파라미터에서 title 가져오기
@@ -80,7 +84,14 @@ const Header = () => {
   // 나머지 페이지: 뒤로가기 버튼 + 중앙 페이지 타이틀
   return (
     <div className="h-[56px] flex bg-pink-100 items-center px-4 relative">
-      <button onClick={() => router.back()}>
+      <button
+        onClick={() => {
+          if (isGiftUploadPage) {
+            setIsBoxEditing(false);
+          }
+          router.back();
+        }}
+      >
         <Image src={ArrowLeftIcon} alt="back" />
       </button>
       <h1 className="text-lg font-bold absolute left-1/2 transform -translate-x-1/2">

--- a/src/stores/gift-upload/useStore.ts
+++ b/src/stores/gift-upload/useStore.ts
@@ -20,7 +20,12 @@ interface GiftStore {
 export const useGiftStore = create<GiftStore>()(
   persist(
     (set) => ({
-      giftBoxes: Array(6).fill({ name: "", filled: false, reason: "" }),
+      giftBoxes: Array(6).fill({
+        name: "",
+        filled: false,
+        reason: "",
+        tagIndex: 0,
+      }),
 
       updateGiftBox: (index, data) =>
         set((state) => {

--- a/src/stores/giftbag/useStore.ts
+++ b/src/stores/giftbag/useStore.ts
@@ -1,11 +1,17 @@
 import { create } from "zustand";
+import { persist } from "zustand/middleware";
 
 interface Store {
   selectedBagIndex: number;
   setSelectedBagIndex: (index: number) => void;
 }
 
-export const useStore = create<Store>((set) => ({
-  selectedBagIndex: 0,
-  setSelectedBagIndex: (index) => set({ selectedBagIndex: index }),
-}));
+export const useStore = create<Store>()(
+  persist(
+    (set) => ({
+      selectedBagIndex: 0,
+      setSelectedBagIndex: (index) => set({ selectedBagIndex: index }),
+    }),
+    { name: "selectedBag-storage" },
+  ),
+);

--- a/src/types/giftbag/types.ts
+++ b/src/types/giftbag/types.ts
@@ -3,6 +3,6 @@ export interface GiftBox {
   reason: string;
   purchase_url?: string;
   tag?: string;
-  tagIndex?: number;
+  tagIndex: number;
   filled: boolean;
 }


### PR DESCRIPTION
### ⚾️ Related Issues
* close #13

### 📝 Task Details
- ~~textarea 한글 이상하게 쳐지는거 수정~~
- ~~태그쪽 로직 수정~~
- ~~클릭 시 이유 보이는거 수정상태에서는 클릭 안해도 바로 보이게 하기~~
- ~~이유 tag, message 상수로 관리~~
- 이미지 업로드 보기
- ~~drawer 컴포넌트명 변경~~
    - ~~drawer 닫기 제대로 동작하도록~~
- ~~툴팁 나오게 하기~~
- ~~보따리 색 변하지 않도록~~
    - selectedBagImage 파일에서 hydrate state 만들어서 관리.
    - zustand persist 관리
        - client에서 hydration(데이터를 불러오기) 되기 전에 초기 상태인 index:0이 먼저 렌더링되면서 0번 index의 보따리가 잠깐 깜빡 하게 되는 상황이 발생.
    
    ⇒ 데이터 불러오는 동안에 스피너 만들어둠
    
    💡 추후 선물 배달하고 나서 보따리 색 초기화해야 함

    

- ~~박스 비우기 시 drawer 내용 변경~~
- ~~선물 상세보기에서 이유 빈 스트링이면 이유 없다는 text 띄워주기~~
- ~~수정상태일 때 상단바 뒤로가기 누르면 수정과 관련한 persist state 바꿔줘야 함~~

### 📂 References
* screenshots, GIFs, etc.

### 💕 Review Requirements
* 손가락과 손목이 곧 부서지겠습니다.
