### PR TITLE
feat: 보따리 생성 api 플로우 수정

### DIFF
--- a/src/api/giftbag/api.ts
+++ b/src/api/giftbag/api.ts
@@ -39,3 +39,42 @@ export const createGiftBag = async ({
 
   return response.json();
 };
+
+{
+  /* 보따리 업데이트 api */
+}
+export const updateGiftBag = async (giftBoxes: GiftBox[]) => {
+  const bundleId = sessionStorage.getItem("giftBagId");
+
+  if (!bundleId) {
+    throw new Error("선물 보따리 ID가 없습니다.");
+  }
+
+  const gifts = giftBoxes.map((gift) => ({
+    id: gift.id,
+    name: gift.name,
+    message: gift.reason,
+    purchaseUrl: gift.purchase_url,
+    imageUrls: gift.imgUrls,
+  }));
+
+  const requestBody = {
+    bundleId,
+    gifts,
+  };
+
+  const response = await fetch(`/api/v1/bundles/${bundleId}`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
+    },
+    body: JSON.stringify(requestBody),
+  });
+
+  if (!response.ok) {
+    throw new Error(`서버 오류: ${response.status}`);
+  }
+
+  return await response.json();
+};

--- a/src/api/giftbag/api.ts
+++ b/src/api/giftbag/api.ts
@@ -44,10 +44,16 @@ export const createGiftBag = async ({
   /* 보따리 업데이트 api */
 }
 export const updateGiftBag = async (giftBoxes: GiftBox[]) => {
-  const bundleId = sessionStorage.getItem("giftBagId");
+  const bundleIdStr = sessionStorage.getItem("giftBagId");
 
-  if (!bundleId) {
+  if (!bundleIdStr) {
     throw new Error("선물 보따리 ID가 없습니다.");
+  }
+
+  const bundleId = parseInt(bundleIdStr, 10);
+
+  if (isNaN(bundleId)) {
+    throw new Error("유효하지 않은 선물 보따리 ID입니다.");
   }
 
   const gifts = giftBoxes.map((gift) => ({

--- a/src/api/giftbag/api.ts
+++ b/src/api/giftbag/api.ts
@@ -56,13 +56,15 @@ export const updateGiftBag = async (giftBoxes: GiftBox[]) => {
     throw new Error("유효하지 않은 선물 보따리 ID입니다.");
   }
 
-  const gifts = giftBoxes.map((gift) => ({
-    id: gift.id,
-    name: gift.name,
-    message: gift.reason,
-    purchaseUrl: gift.purchase_url,
-    imageUrls: gift.imgUrls,
-  }));
+  const gifts = giftBoxes
+    .filter((gift) => gift.filled)
+    .map((gift) => ({
+      id: gift.id,
+      name: gift.name,
+      message: gift.reason,
+      purchaseUrl: gift.purchase_url,
+      imageUrls: gift.imgUrls,
+    }));
 
   const requestBody = {
     bundleId,

--- a/src/app/giftbag/add/page.tsx
+++ b/src/app/giftbag/add/page.tsx
@@ -54,7 +54,13 @@ const Page = () => {
   const handleClickButton = async () => {
     try {
       if (giftBagId) {
-        await updateGiftBag(giftBoxes);
+        const res = await updateGiftBag(giftBoxes);
+
+        if (res?.gifts?.length) {
+          res.gifts.forEach((gift: GiftBox, index: number) => {
+            useGiftStore.getState().updateGiftBox(index, { id: gift.id });
+          });
+        }
       } else {
         await mutation.mutateAsync();
       }

--- a/src/app/giftbag/add/page.tsx
+++ b/src/app/giftbag/add/page.tsx
@@ -5,7 +5,7 @@ import Chip from "@/components/giftbag/Chip";
 import GiftList from "@/components/giftbag/GiftList";
 import { Button } from "@/components/ui/button";
 import { useRouter } from "next/navigation";
-import { createGiftBag } from "@/api/giftbag/api";
+import { createGiftBag, updateGiftBag } from "@/api/giftbag/api";
 import {
   useSelectedBagStore,
   useGiftBagStore,
@@ -51,9 +51,17 @@ const Page = () => {
     },
   });
 
-  const handleClickButton = () => {
-    mutation.mutate();
-    router.push("/giftbag/delivery?step=1");
+  const handleClickButton = async () => {
+    try {
+      if (giftBagId) {
+        await updateGiftBag(giftBoxes);
+      } else {
+        await mutation.mutateAsync();
+      }
+      router.push("/giftbag/delivery?step=1");
+    } catch (error) {
+      alert(`보따리 저장에 실패했습니다. ${error}`);
+    }
   };
 
   return (

--- a/src/app/giftbag/add/page.tsx
+++ b/src/app/giftbag/add/page.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/stores/giftbag/useStore";
 import { useMutation } from "@tanstack/react-query";
 import { useState, useEffect } from "react";
+import { GiftBox } from "@/types/giftbag/types";
 
 const Page = () => {
   const { giftBoxes } = useGiftStore();
@@ -40,6 +41,12 @@ const Page = () => {
     onSuccess: (res) => {
       if (res?.id) {
         setGiftBagId(res.id);
+      }
+
+      if (res?.gifts?.length) {
+        res.gifts.forEach((gift: GiftBox, index: number) => {
+          useGiftStore.getState().updateGiftBox(index, { id: gift.id });
+        });
       }
     },
   });

--- a/src/app/giftbag/add/page.tsx
+++ b/src/app/giftbag/add/page.tsx
@@ -5,11 +5,49 @@ import Chip from "@/components/giftbag/Chip";
 import GiftList from "@/components/giftbag/GiftList";
 import { Button } from "@/components/ui/button";
 import { useRouter } from "next/navigation";
+import { createGiftBag } from "@/api/giftbag/api";
+import {
+  useSelectedBagStore,
+  useGiftBagStore,
+} from "@/stores/giftbag/useStore";
+import { useMutation } from "@tanstack/react-query";
+import { useState, useEffect } from "react";
 
 const Page = () => {
   const { giftBoxes } = useGiftStore();
   const filledGiftCount = giftBoxes.filter((gift) => gift.filled).length;
   const router = useRouter();
+  const { selectedBagIndex } = useSelectedBagStore();
+  const { giftBagName } = useGiftBagStore();
+
+  const [giftBagId, setGiftBagId] = useState<string | null>(
+    () => sessionStorage.getItem("giftBagId") || null,
+  );
+
+  useEffect(() => {
+    if (giftBagId) {
+      sessionStorage.setItem("giftBagId", giftBagId);
+    }
+  }, [giftBagId]);
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      createGiftBag({
+        giftBagName,
+        selectedBagIndex,
+        giftBoxes,
+      }),
+    onSuccess: (res) => {
+      if (res?.id) {
+        setGiftBagId(res.id);
+      }
+    },
+  });
+
+  const handleClickButton = () => {
+    mutation.mutate();
+    router.push("/giftbag/delivery?step=1");
+  };
 
   return (
     <div className="h-full bg-pink-50 px-4">
@@ -24,7 +62,7 @@ const Page = () => {
           <Button
             disabled={filledGiftCount <= 1}
             size="lg"
-            onClick={() => router.push("/giftbag/delivery?step=1")}
+            onClick={handleClickButton}
           >
             선물 배달하러 가기
           </Button>

--- a/src/app/giftbag/delivery/step2.tsx
+++ b/src/app/giftbag/delivery/step2.tsx
@@ -40,10 +40,11 @@ const Step2 = ({ onNextStep }: Step2Props) => {
     setSelectedBagIndex(0);
     setGiftBagName("");
 
-    sessionStorage.removeItem("giftBagId");
+    sessionStorage.removeItem("giftBagId"); //세션스토리지에서 보따리 id 삭제
   };
 
   const handleClickButton = () => {
+    //배달부 선택하기 api를 여기에 두신 후에 resetStore가 실행되면 될 것 같아요!
     resetStore();
     onNextStep(character || "포리");
   };

--- a/src/app/giftbag/delivery/step2.tsx
+++ b/src/app/giftbag/delivery/step2.tsx
@@ -33,6 +33,7 @@ const Step2 = ({ onNextStep }: Step2Props) => {
         purchase_url: "",
         tag: "",
         imgUrls: [],
+        id: null,
       }),
     });
 

--- a/src/app/giftbag/delivery/step2.tsx
+++ b/src/app/giftbag/delivery/step2.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { Fragment, useEffect, useState } from "react";
+import { Fragment } from "react";
 import Image from "next/image";
 import { useSearchParams } from "next/navigation";
-import { useMutation } from "@tanstack/react-query";
 
 import { deliveryCharacterData } from "@/data/deliveryCharacterData";
 import { Button } from "@/components/ui/button";
@@ -12,7 +11,6 @@ import {
   useGiftBagStore,
   useSelectedBagStore,
 } from "@/stores/giftbag/useStore";
-import { createGiftBag } from "@/api/giftbag/api";
 
 interface Step2Props {
   onNextStep: (selectedCharacter: string) => void;
@@ -21,19 +19,9 @@ interface Step2Props {
 const Step2 = ({ onNextStep }: Step2Props) => {
   const searchParams = useSearchParams();
   const character = searchParams ? searchParams.get("character") : null;
-  const { setSelectedBagIndex, selectedBagIndex } = useSelectedBagStore();
-  const { setGiftBagName, giftBagName } = useGiftBagStore();
-  const { giftBoxes } = useGiftStore();
 
-  const [giftBagId, setGiftBagId] = useState<string | null>(
-    () => sessionStorage.getItem("giftBagId") || null,
-  );
-
-  useEffect(() => {
-    if (giftBagId) {
-      sessionStorage.setItem("giftBagId", giftBagId);
-    }
-  }, [giftBagId]);
+  const { setSelectedBagIndex } = useSelectedBagStore();
+  const { setGiftBagName } = useGiftBagStore();
 
   const resetStore = () => {
     useGiftStore.setState({
@@ -52,21 +40,10 @@ const Step2 = ({ onNextStep }: Step2Props) => {
     setGiftBagName("");
   };
 
-  const mutation = useMutation({
-    mutationFn: () =>
-      createGiftBag({
-        giftBagName,
-        selectedBagIndex,
-        giftBoxes,
-      }),
-    onSuccess: (res) => {
-      if (res?.id) {
-        setGiftBagId(res.id);
-      }
-      resetStore();
-      onNextStep(character || "포리");
-    },
-  });
+  const handleClickButton = () => {
+    resetStore();
+    onNextStep(character || "포리");
+  };
 
   return (
     <div className="h-[calc(100%-52px)] w-full flex flex-col items-center justify-center gap-7">
@@ -108,12 +85,7 @@ const Step2 = ({ onNextStep }: Step2Props) => {
         </div>
       </section>
       <div className="w-full px-4 absolute bottom-4">
-        <Button
-          onClick={() => {
-            mutation.mutate();
-          }}
-          size="lg"
-        >
+        <Button onClick={handleClickButton} size="lg">
           선물 보따리 배달하기
         </Button>
       </div>

--- a/src/app/giftbag/delivery/step2.tsx
+++ b/src/app/giftbag/delivery/step2.tsx
@@ -39,6 +39,8 @@ const Step2 = ({ onNextStep }: Step2Props) => {
 
     setSelectedBagIndex(0);
     setGiftBagName("");
+
+    sessionStorage.removeItem("giftBagId");
   };
 
   const handleClickButton = () => {

--- a/src/components/giftbag/GiftList.tsx
+++ b/src/components/giftbag/GiftList.tsx
@@ -42,6 +42,7 @@ const GiftList = ({ value }: GiftListProps) => {
         tag: "",
         filled: false,
         imgUrls: [],
+        id: null,
       });
     }
     setSelectedBox(null);

--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -154,10 +154,35 @@ const Header = () => {
 
   const handleTempSave = async () => {
     if (giftBagId) {
-      const res = await updateGiftBag(giftBoxes);
-      if (res?.gifts?.length) {
-        res.gifts.forEach((gift: GiftBox, index: number) => {
-          useGiftStore.getState().updateGiftBox(index, { id: gift.id });
+      try {
+        const res = await updateGiftBag(giftBoxes);
+
+        if (res?.gifts?.length) {
+          res.gifts.forEach((gift: GiftBox, index: number) => {
+            useGiftStore.getState().updateGiftBox(index, { id: gift.id });
+          });
+        }
+
+        toast({
+          title: "임시저장 성공",
+          description: "보따리가 임시저장되었습니다.",
+          style: {
+            position: "fixed",
+            bottom: "16px",
+            right: "12px",
+            width: "400px",
+          },
+        });
+      } catch (error) {
+        toast({
+          title: "임시저장 실패",
+          description: `보따리 임시저장에 실패했습니다. ${error}`,
+          style: {
+            position: "fixed",
+            bottom: "16px",
+            right: "12px",
+            width: "400px",
+          },
         });
       }
     } else {

--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -181,11 +181,23 @@ const Header = () => {
         toast({
           title: "임시저장 성공",
           description: "보따리가 임시저장되었습니다.",
+          style: {
+            position: "fixed",
+            bottom: "16px",
+            right: "12px",
+            width: "400px",
+          },
         });
       } catch (error) {
         toast({
           title: "임시저장 실패",
           description: `보따리 임시저장에 실패했습니다. ${error}`,
+          style: {
+            position: "fixed",
+            bottom: "16px",
+            right: "12px",
+            width: "400px",
+          },
         });
       }
     }

--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -154,7 +154,12 @@ const Header = () => {
 
   const handleTempSave = async () => {
     if (giftBagId) {
-      updateGiftBag(giftBoxes);
+      const res = await updateGiftBag(giftBoxes);
+      if (res?.gifts?.length) {
+        res.gifts.forEach((gift: GiftBox, index: number) => {
+          useGiftStore.getState().updateGiftBox(index, { id: gift.id });
+        });
+      }
     } else {
       try {
         const res = await createGiftBag({

--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -24,6 +24,7 @@ import SettingIcon from "../../public/icons/setting_large.svg";
 import ArrowLeftIcon from "../../public/icons/arrow_left_large.svg";
 import { createGiftBag } from "@/api/giftbag/api";
 import { toast } from "@/hooks/use-toast";
+import { GiftBox } from "@/types/giftbag/types";
 
 // 정적 title 관리
 const pageTitles: { [key: string]: string } = {
@@ -141,9 +142,34 @@ const Header = () => {
     setShowTempSave(filledCount >= 2);
   }, [giftBoxes]);
 
+  const [giftBagId, setGiftBagId] = useState<string | null>(
+    () => sessionStorage.getItem("giftBagId") || null,
+  );
+
+  useEffect(() => {
+    if (giftBagId) {
+      sessionStorage.setItem("giftBagId", giftBagId);
+    }
+  }, [giftBagId]);
+
   const handleTempSave = async () => {
     try {
-      await createGiftBag({ giftBagName, selectedBagIndex, giftBoxes });
+      const res = await createGiftBag({
+        giftBagName,
+        selectedBagIndex,
+        giftBoxes,
+      });
+
+      if (res?.id) {
+        setGiftBagId(res.id);
+      }
+
+      if (res?.gifts?.length) {
+        res.gifts.forEach((gift: GiftBox, index: number) => {
+          useGiftStore.getState().updateGiftBox(index, { id: gift.id });
+        });
+      }
+
       toast({
         title: "임시저장 성공",
         description: "보따리가 임시저장되었습니다.",

--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -22,7 +22,7 @@ import { Button } from "@/components/ui/button";
 import LogoIcon from "../../public/icons/logo.svg";
 import SettingIcon from "../../public/icons/setting_large.svg";
 import ArrowLeftIcon from "../../public/icons/arrow_left_large.svg";
-import { createGiftBag } from "@/api/giftbag/api";
+import { createGiftBag, updateGiftBag } from "@/api/giftbag/api";
 import { toast } from "@/hooks/use-toast";
 import { GiftBox } from "@/types/giftbag/types";
 
@@ -153,32 +153,36 @@ const Header = () => {
   }, [giftBagId]);
 
   const handleTempSave = async () => {
-    try {
-      const res = await createGiftBag({
-        giftBagName,
-        selectedBagIndex,
-        giftBoxes,
-      });
+    if (giftBagId) {
+      updateGiftBag(giftBoxes);
+    } else {
+      try {
+        const res = await createGiftBag({
+          giftBagName,
+          selectedBagIndex,
+          giftBoxes,
+        });
 
-      if (res?.id) {
-        setGiftBagId(res.id);
-      }
+        if (res?.id) {
+          setGiftBagId(res.id);
+        }
 
-      if (res?.gifts?.length) {
-        res.gifts.forEach((gift: GiftBox, index: number) => {
-          useGiftStore.getState().updateGiftBox(index, { id: gift.id });
+        if (res?.gifts?.length) {
+          res.gifts.forEach((gift: GiftBox, index: number) => {
+            useGiftStore.getState().updateGiftBox(index, { id: gift.id });
+          });
+        }
+
+        toast({
+          title: "임시저장 성공",
+          description: "보따리가 임시저장되었습니다.",
+        });
+      } catch (error) {
+        toast({
+          title: "임시저장 실패",
+          description: `보따리 임시저장에 실패했습니다. ${error}`,
         });
       }
-
-      toast({
-        title: "임시저장 성공",
-        description: "보따리가 임시저장되었습니다.",
-      });
-    } catch (error) {
-      toast({
-        title: "임시저장 실패",
-        description: `보따리 임시저장에 실패했습니다. ${error}`,
-      });
     }
   };
 

--- a/src/types/giftbag/types.ts
+++ b/src/types/giftbag/types.ts
@@ -6,6 +6,7 @@ export interface GiftBox {
   tagIndex: number;
   filled: boolean;
   imgUrls: string[];
+  id?: number | null;
 }
 
 {


### PR DESCRIPTION
### ⚾️ Related Issues
* close #69 

### 📝 Task Details
* /giftbag/add -> 선물이 2개 이상일 때 임시저장 버튼이 나타납니다.
* **sessionStorage에 보따리 id가 없을 때** -> `보따리 생성 api`
   - 보따리 생성 api response로 각 선물 박스마다 id를 주는데, 해당 id를 localStorage에 저장중인 giftBoxes의 각 선물 박스에 새로 넣어줌(보따리 업데이트 시 request body에 각 선물 박스의 id가 필요.)
* **sessionStorage에 보따리 id가 있을 때** -> `보따리 업데이트 api`
* giftbag/delivery?step=2에서, 버튼을 눌렀을 시 모든 localStorage에 저장되던 것들 초기화시킴. (상단 헤더의 돌아가기 버튼을 통해 이전 페이지로 갈 수 있기 때문에 초기화를 해당 페이지에서 진행합니다.) 주석을 달아놓았는데, 배달부 선택하기api 에서 사용하는 giftBagId 또한 해당 페이지에서 초기화시킵니다! 따라서 초기화 함수 (resetStore)를 실행시키기 전에 배달부 선택 api를 쏘시면 될 것 같아요!

* **임시저장 버튼, 선물 배달하러 가기 버튼 눌렀을 때 id 유무에 따라 보따리 생성 api / 보따리 업데이트 api를 연결해두었습니다.**

### 📂 References
* screenshots, GIFs, etc.

### 💕 Review Requirements
* api 요청하는 코드가 어떤건 훅이 있고. .. 어떤건 훅이 없고 그러는데 마음이 급해서......... 시간이 나면 리팩토링해야할 것 같습니다.
