### PR TITLE
feat: 로컬스토리지에 저장해둔 것들 초기화

### DIFF
--- a/src/app/giftbag/list/[giftbagId]/answer/page.tsx
+++ b/src/app/giftbag/list/[giftbagId]/answer/page.tsx
@@ -117,7 +117,7 @@ const Page = () => {
                   </div>
                   <Button
                     variant="ghost"
-                    className="absolute left-44 top-1/2 transform -translate-y-1/2"
+                    className="absolute left-44 top-1/2 transform -translate-y-1/2 hover:opacity-70"
                     onClick={() =>
                       router.push(`/giftbag/list/${giftBagId}/${gift.id}`)
                     }

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -10,10 +10,42 @@ import MainGraphic from "/public/img/main_graphic.svg";
 import ArrowRightIcon from "/public/icons/arrow_right_small.svg";
 
 import { useGiftBagPreview } from "@/hooks/api/useMyGiftBagPreview";
+import { useGiftStore } from "@/stores/gift-upload/useStore";
+import {
+  useSelectedBagStore,
+  useGiftBagStore,
+} from "@/stores/giftbag/useStore";
+import { useEffect } from "react";
 
 const Page = () => {
   const { data, isLoading } = useGiftBagPreview();
   const hasGiftBag = data?.result?.length;
+
+  const { setSelectedBagIndex } = useSelectedBagStore();
+  const { setGiftBagName } = useGiftBagStore();
+
+  const resetStore = () => {
+    //추후 util로 빼야함
+    useGiftStore.setState({
+      giftBoxes: Array(6).fill({
+        name: "",
+        filled: false,
+        reason: "",
+        tagIndex: 0,
+        purchase_url: "",
+        tag: "",
+        imgUrls: [],
+        id: null,
+      }),
+    });
+
+    setSelectedBagIndex(0);
+    setGiftBagName("");
+  };
+
+  useEffect(() => {
+    resetStore();
+  }, []);
 
   return (
     <main className="flex flex-col gap-10 items-center justify-center pt-3 px-4">

--- a/src/components/gift-upload/GiftForm.tsx
+++ b/src/components/gift-upload/GiftForm.tsx
@@ -8,7 +8,6 @@ import { Button } from "../ui/button";
 import InputLink from "./InputLink";
 import InputReason from "./InputReason";
 import UploadImageList from "./UploadImageList";
-import ErrorMessage from "../common/ErrorMessage";
 import { GIFT_NAME_MAX_LENGTH } from "@/constants/constants";
 import {
   useTagIndexStore,
@@ -48,10 +47,10 @@ const GiftForm = () => {
   const [giftReason, setGiftReason] = useState(existingGift.reason || "");
   const [giftLink, setGiftLink] = useState(existingGift.purchase_url || "");
   const [giftTag, setGiftTag] = useState(existingGift.tag || "");
-  const [isSubmitted, setIsSubmitted] = useState(false);
 
   const [isGiftNameFilled, setIsGiftNameFilled] = useState(!!giftName);
   const [isReasonFilled, setIsReasonFilled] = useState(!!giftReason);
+  const [isFormValid, setIsFormValid] = useState(false);
 
   const reasonRef = useRef<HTMLDivElement>(null);
   const linkRef = useRef<HTMLDivElement>(null);
@@ -94,6 +93,10 @@ const GiftForm = () => {
     }
   }, [giftReason]);
 
+  useEffect(() => {
+    setIsFormValid(giftName.trim().length > 0 && combinedImages.length > 0);
+  }, [giftName, combinedImages]);
+
   const uploadMutation = useMutation<string[], Error, FormData>({
     mutationFn: uploadGiftImages,
     onSuccess: (uploadedUrls: string[]) => {
@@ -106,11 +109,6 @@ const GiftForm = () => {
   });
 
   const handleSubmit = () => {
-    if (combinedImages.length === 0 || giftName.length === 0) {
-      setIsSubmitted(true);
-      return;
-    }
-
     const existingItems = combinedImages
       .filter((item) => item.type === "existing")
       .map((item) => item.url);
@@ -162,9 +160,6 @@ const GiftForm = () => {
               setCombinedImages={setCombinedImages}
               maxImages={5}
             />
-            {isSubmitted && combinedImages.length === 0 && (
-              <ErrorMessage message="필수 입력 정보입니다." />
-            )}
           </div>
           <div className="flex flex-col gap-2">
             <CharacterCountInput
@@ -173,9 +168,6 @@ const GiftForm = () => {
               placeholder="선물명을 적어주세요"
               onChange={(text) => setGiftName(text)}
             />
-            {isSubmitted && giftName.length === 0 && (
-              <ErrorMessage message="필수 입력 정보입니다." />
-            )}
           </div>
         </div>
         {isGiftNameFilled && (
@@ -205,7 +197,7 @@ const GiftForm = () => {
         )}
       </div>
       <div className="sticky bottom-4 w-full left-0">
-        <Button size="lg" onClick={handleSubmit}>
+        <Button size="lg" onClick={handleSubmit} disabled={!isFormValid}>
           {isBoxEditing ? "수정 완료" : "채우기 완료"}
         </Button>
       </div>


### PR DESCRIPTION
### ⚾️ Related Issues
* close #[issue_number]

### 📝 Task Details
* 보따리 결과 페이지에서 화살표 버튼에 `hover:opacity-70`을 추가했습니다.
* home 화면이 렌더링되면 selectedGiftBagIndex (보따리 색 구분을 위함), giftBagName (보따리 이름), giftBoxes(선물상자들)을 초기화합니다.
* 선물 상세 입력 페이지에서 이미지, 이름 미입력 시 에러메세지를 띄우는 것이 아닌, 버튼 disabled로 변경했습니다.

### 📂 References
* screenshots, GIFs, etc.

### 💕 Review Requirements
* Please fill out your review request.
