### PR TITLE
feat: 툴팁 나오는 타이밍 수정

### DIFF
--- a/src/components/giftbag/GiftList.tsx
+++ b/src/components/giftbag/GiftList.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import {
@@ -45,9 +45,13 @@ const GiftList = ({ value }: { value: GiftBox[] }) => {
     setSelectedIndex(null);
   };
 
-  const oneOrMoreFilledBox = giftBoxes.filter(
-    (box) => box && box.filled,
-  ).length;
+  const [showTooltip, setShowTooltip] = useState(false);
+
+  useEffect(() => {
+    setShowTooltip(true);
+    const timer = setTimeout(() => setShowTooltip(false), 3000);
+    return () => clearTimeout(timer);
+  }, []);
 
   return (
     <>
@@ -96,8 +100,8 @@ const GiftList = ({ value }: { value: GiftBox[] }) => {
                       router.push(`/gift-upload?index=${index}`);
                     }}
                   >
-                    {index === 0 && !oneOrMoreFilledBox ? (
-                      <Tooltip>
+                    {index === 0 ? (
+                      <Tooltip open={showTooltip}>
                         <TooltipTrigger asChild>
                           <Image
                             src={DEFAULT_IMAGES[index % 2]}


### PR DESCRIPTION
### ⚾️ Related Issues

- close #109 

### 📝 Task Details

- 선물 보따리 채우기 화면 첫 렌더링 시 툴팁이 자동으로 나오고, 유지 시간은 3초로 해두었습니다.
- 영상에서 브라우저 상단이 안보여서,, 마지막쯤에 새로고침을 해도 툴팁이 안나오는 것까지 확인했습니다

https://github.com/user-attachments/assets/49041e8b-1bfd-4ac7-ae4e-b686511185bf


### 📂 References

- screenshots, GIFs, etc.

### 💕 Review Requirements

- Please fill out your review request.
