### PR TITLE
feat: 선물 사진 순서 바꾸기 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "dnd-12th-5-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/modifiers": "^9.0.0",
+        "@dnd-kit/sortable": "^10.0.0",
         "@radix-ui/react-dialog": "^1.1.6",
         "@radix-ui/react-slot": "^1.1.2",
         "@radix-ui/react-toast": "^1.2.6",
@@ -64,6 +67,73 @@
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/modifiers": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
+      "integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "analyze": "cross-env ANALYZE=true next build"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
+    "@dnd-kit/sortable": "^10.0.0",
     "@radix-ui/react-dialog": "^1.1.6",
     "@radix-ui/react-slot": "^1.1.2",
     "@radix-ui/react-toast": "^1.2.6",

--- a/src/app/giftbag/[id]/step2.tsx
+++ b/src/app/giftbag/[id]/step2.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/stores/giftbag/useStore";
 import { Step2Props } from "@/types/giftbag/types";
 import { RESPONSE_TAGS } from "@/constants/constants";
+import { toast } from "@/hooks/use-toast";
 
 const Step2 = ({ gifts, giftResultData, isCompleted }: Step2Props) => {
   const router = useRouter();
@@ -77,13 +78,20 @@ const Step2 = ({ gifts, giftResultData, isCompleted }: Step2Props) => {
       );
 
       if (!response.ok) {
-        throw new Error("답변 제출에 실패했습니다.");
+        toast({
+          variant: "destructive",
+          description: "답변 전송에 실패했습니다.",
+        });
+        throw new Error("답변 전송에 실패했습니다.");
       }
       setIsUploadedAnswer(true);
       router.push(`/giftbag/${link}?step=3`);
     } catch (error) {
-      console.error("Error submitting responses:", error);
-      alert("오류가 발생했습니다. 다시 시도해주세요.");
+      console.error(error);
+      toast({
+        variant: "destructive",
+        description: "답변 전송에 실패했습니다.",
+      });
     }
   };
 

--- a/src/components/gift-upload/ImageCard.tsx
+++ b/src/components/gift-upload/ImageCard.tsx
@@ -9,6 +9,7 @@ const ImageCard = ({
   isPrimary,
   onDelete,
   cursorPointer,
+  dragHandleProps,
 }: ImageCardProps) => {
   const isCursorPointer = cursorPointer ? "cursor-pointer" : "cursor-none";
 
@@ -28,6 +29,7 @@ const ImageCard = ({
           height={88}
           className="w-full h-full object-cover"
           priority
+          {...dragHandleProps}
         />
         {isPrimary && (
           <div className="absolute bottom-0 w-[88px] bg-[#0F0F10] opacity-70 text-gray-300 text-xs pt-0.5 text-center rounded-bl-[10px] rounded-br-[10px] h-5">

--- a/src/components/gift-upload/ImageCard.tsx
+++ b/src/components/gift-upload/ImageCard.tsx
@@ -8,13 +8,10 @@ const ImageCard = ({
   src,
   isPrimary,
   onDelete,
-  cursorPointer,
   dragHandleProps,
 }: ImageCardProps) => {
-  const isCursorPointer = cursorPointer ? "cursor-pointer" : "cursor-none";
-
   return (
-    <div className={`relative ${isCursorPointer}`}>
+    <div className="relative">
       <button
         className="absolute top-[-8px] right-[-8px] z-10"
         onClick={onDelete}

--- a/src/components/gift-upload/ImageCard.tsx
+++ b/src/components/gift-upload/ImageCard.tsx
@@ -4,9 +4,16 @@ import EraseIcon from "../../../public/icons/btn_erase.svg";
 import { Icon } from "../common/Icon";
 import { ImageCardProps } from "@/types/components/types";
 
-const ImageCard = ({ src, isPrimary, onDelete }: ImageCardProps) => {
+const ImageCard = ({
+  src,
+  isPrimary,
+  onDelete,
+  cursorPointer,
+}: ImageCardProps) => {
+  const isCursorPointer = cursorPointer ? "cursor-pointer" : "cursor-none";
+
   return (
-    <div className="relative">
+    <div className={`relative ${isCursorPointer}`}>
       <button
         className="absolute top-[-8px] right-[-8px] z-10"
         onClick={onDelete}

--- a/src/components/gift-upload/SortableImageWrapper.tsx
+++ b/src/components/gift-upload/SortableImageWrapper.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+
+const SortableImageWrapper = ({
+  id,
+  children,
+}: {
+  id: string;
+  children: React.ReactNode;
+}) => {
+  const { attributes, listeners, setNodeRef, transform, transition } =
+    useSortable({ id });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+  return (
+    <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
+      {children}
+    </div>
+  );
+};
+
+export default SortableImageWrapper;

--- a/src/components/gift-upload/SortableImageWrapper.tsx
+++ b/src/components/gift-upload/SortableImageWrapper.tsx
@@ -1,24 +1,25 @@
 "use client";
 
+import { SortableImageWrapperProps } from "@/types/components/types";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 
-const SortableImageWrapper = ({
-  id,
-  children,
-}: {
-  id: string;
-  children: React.ReactNode;
-}) => {
+const SortableImageWrapper = ({ id, children }: SortableImageWrapperProps) => {
   const { attributes, listeners, setNodeRef, transform, transition } =
     useSortable({ id });
+
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
   };
+
+  const dragHandleProps = { ...attributes, ...listeners };
+
   return (
-    <div ref={setNodeRef} style={style} {...attributes} {...listeners}>
-      {children}
+    <div ref={setNodeRef} style={style}>
+      {typeof children === "function"
+        ? children({ dragHandleProps })
+        : children}
     </div>
   );
 };

--- a/src/components/gift-upload/UploadImageList.tsx
+++ b/src/components/gift-upload/UploadImageList.tsx
@@ -6,6 +6,13 @@ import Image from "next/image";
 import { ImageItem } from "@/types/gift-upload/types";
 import { UploadImageListProps } from "@/types/components/types";
 import { IMAGE_EXTENSIONS } from "@/constants/constants";
+import { closestCenter, DndContext, DragEndEvent } from "@dnd-kit/core";
+import {
+  arrayMove,
+  horizontalListSortingStrategy,
+  SortableContext,
+} from "@dnd-kit/sortable";
+import SortableImageWrapper from "./SortableImageWrapper";
 
 const UploadImageList = ({
   combinedImages,
@@ -43,6 +50,17 @@ const UploadImageList = ({
     setCombinedImages(newItems);
   };
 
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const oldIdx = combinedImages.findIndex((item) => item.url === active.id);
+    const newIdx = combinedImages.findIndex((item) => item.url === over.id);
+
+    const newList = arrayMove(combinedImages, oldIdx, newIdx);
+    setCombinedImages(newList);
+  };
+
   return (
     <div className="flex gap-2 whitespace-nowrap">
       <label
@@ -65,15 +83,24 @@ const UploadImageList = ({
           multiple
         />
       </label>
-      {combinedImages.map((item, index) => (
-        <ImageCard
-          key={index}
-          src={item.url}
-          isPrimary={index === 0}
-          onDelete={() => handleDelete(index)}
-          cursorPointer={true}
-        />
-      ))}
+      <DndContext collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+        <SortableContext
+          items={combinedImages.map((item) => item.url)}
+          strategy={horizontalListSortingStrategy}
+        >
+          {combinedImages.map((item, index) => (
+            <SortableImageWrapper key={item.url} id={item.url}>
+              <ImageCard
+                key={index}
+                src={item.url}
+                isPrimary={index === 0}
+                onDelete={() => handleDelete(index)}
+                cursorPointer={true}
+              />
+            </SortableImageWrapper>
+          ))}
+        </SortableContext>
+      </DndContext>
     </div>
   );
 };

--- a/src/components/gift-upload/UploadImageList.tsx
+++ b/src/components/gift-upload/UploadImageList.tsx
@@ -95,7 +95,6 @@ const UploadImageList = ({
                   src={item.url}
                   isPrimary={index === 0}
                   onDelete={() => handleDelete(index)}
-                  cursorPointer={true}
                   dragHandleProps={dragHandleProps}
                 />
               )}

--- a/src/components/gift-upload/UploadImageList.tsx
+++ b/src/components/gift-upload/UploadImageList.tsx
@@ -71,6 +71,7 @@ const UploadImageList = ({
           src={item.url}
           isPrimary={index === 0}
           onDelete={() => handleDelete(index)}
+          cursorPointer={true}
         />
       ))}
     </div>

--- a/src/components/gift-upload/UploadImageList.tsx
+++ b/src/components/gift-upload/UploadImageList.tsx
@@ -90,13 +90,15 @@ const UploadImageList = ({
         >
           {combinedImages.map((item, index) => (
             <SortableImageWrapper key={item.url} id={item.url}>
-              <ImageCard
-                key={index}
-                src={item.url}
-                isPrimary={index === 0}
-                onDelete={() => handleDelete(index)}
-                cursorPointer={true}
-              />
+              {({ dragHandleProps }) => (
+                <ImageCard
+                  src={item.url}
+                  isPrimary={index === 0}
+                  onDelete={() => handleDelete(index)}
+                  cursorPointer={true}
+                  dragHandleProps={dragHandleProps}
+                />
+              )}
             </SortableImageWrapper>
           ))}
         </SortableContext>

--- a/src/components/giftbag/GiftList.tsx
+++ b/src/components/giftbag/GiftList.tsx
@@ -24,6 +24,10 @@ const GiftList = ({ value }: { value: GiftBox[] }) => {
 
   const { giftBoxes, updateGiftBox } = useGiftStore();
 
+  const filledGiftCount = giftBoxes.filter(
+    (gift) => gift && gift.filled === true,
+  ).length;
+
   const emptyGiftBox = () => {
     if (selectedIndex !== null) {
       updateGiftBox(selectedIndex, {
@@ -43,9 +47,12 @@ const GiftList = ({ value }: { value: GiftBox[] }) => {
   const [showTooltip, setShowTooltip] = useState(false);
 
   useEffect(() => {
-    setShowTooltip(true);
-    const timer = setTimeout(() => setShowTooltip(false), 3000);
-    return () => clearTimeout(timer);
+    if (filledGiftCount === 0) {
+      setShowTooltip(true);
+      const timer = setTimeout(() => setShowTooltip(false), 3000);
+      return () => clearTimeout(timer);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (

--- a/src/types/components/types.ts
+++ b/src/types/components/types.ts
@@ -75,7 +75,6 @@ export interface ImageCardProps {
   src: string;
   isPrimary?: boolean;
   onDelete: () => void;
-  cursorPointer?: boolean;
   dragHandleProps?: React.HTMLAttributes<HTMLElement>;
 }
 

--- a/src/types/components/types.ts
+++ b/src/types/components/types.ts
@@ -74,6 +74,7 @@ export interface ImageCardProps {
   src: string;
   isPrimary?: boolean;
   onDelete: () => void;
+  cursorPointer?: boolean;
 }
 
 export interface InputLinkProps {

--- a/src/types/components/types.ts
+++ b/src/types/components/types.ts
@@ -1,3 +1,4 @@
+import { HTMLAttributes, ReactNode } from "react";
 import { ImageItem } from "../gift-upload/types";
 import {
   FilledGiftListPreview,
@@ -75,6 +76,16 @@ export interface ImageCardProps {
   isPrimary?: boolean;
   onDelete: () => void;
   cursorPointer?: boolean;
+  dragHandleProps?: React.HTMLAttributes<HTMLElement>;
+}
+
+type DragHandleProps = {
+  dragHandleProps: HTMLAttributes<HTMLElement>;
+};
+
+export interface SortableImageWrapperProps {
+  id: string;
+  children: ReactNode | ((props: DragHandleProps) => ReactNode);
 }
 
 export interface InputLinkProps {


### PR DESCRIPTION
### ⚾️ Related Issues

- close #108 

### 📝 Task Details

- dnd-kit 라이브러리를 설치했습니다. pull 받으신 후 npm i 해주세요!
- dnd-kit 라이브러리를 활용해 사진 순서를 drag and drop해 바꾸는 기능을 추가하였습니다. 이에 따라 대표사진도 바뀌게 됩니다. (동영상으로 기록해두었는데 용량이 너무 커서 첨부가 불가합니다,,ㅎㅎ 확인해주세요)

- 0번이 아닌 1번 선물박스가 채워져있음에도 불구하고 툴팁이 나와서 이 부분 수정했습니다. (채워진 선물박스가 0개라면 화면 렌더링 시 툴팁 띄움)

### 📂 References

- screenshots, GIFs, etc.

### 💕 Review Requirements

- 답변 전송 api 요청 실패 시 toast를 띄워두었습니다. api 에러 처리에 관련해서 어떻게 통일하면 좋을 지 프론트엔드 회의가 필요할 것 같아요.
- shadcn에서 기본적으로 제공하는 스켈레톤ui가 있는데 이 부분 전체 회의에서 말해보면 좋을 것 같아요
- 나머지 이슈들은 디자이너분들의 화면 수정 후 이루어져야할 것 같습니다.
