### PR TITLE
design: 카카오톡으로 시작하기 버튼 hover 시 투명도 제거

### DIFF
--- a/src/components/common/KakaoLoginButton.tsx
+++ b/src/components/common/KakaoLoginButton.tsx
@@ -5,7 +5,7 @@ const KakaoLoginButton = ({ link }: { link: string }) => {
   return (
     <a
       href={link}
-      className="bg-[#FEE500] flex py-[17px] justify-center rounded-sm px-4 hover:opacity-90"
+      className="bg-[#FEE500] flex py-[17px] justify-center rounded-sm px-4"
     >
       <Icon src={LogoKakaoIcon} alt="logo" className="absolute left-[34px]" />
       <p className="text-sm font-medium">카카오톡으로 시작하기</p>


### PR DESCRIPTION
### ⚾️ Related Issues

- close #[issue_number]

### 📝 Task Details

- 카카오톡으로 시작하기 버튼 hover 시 투명도 제거하였습니다.

### 📂 References

- screenshots, GIFs, etc.

### 💕 Review Requirements

- Please fill out your review request.
