### PR TITLE
design: mobile safari 호환성을 위해 100vh에서 100svh로 변경

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -48,16 +48,16 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${pretendard.variable} ${nanumSquareRound.variable} antialiased `}
+        className={`${pretendard.variable} ${nanumSquareRound.variable} antialiased`}
       >
-        <div className="max-w-[430px] min-w-[375px] mx-auto min-h-screen flex flex-col relative">
+        <div className="max-w-[430px] min-w-[375px] mx-auto flex flex-col relative">
           <Suspense>
             <PageTransition>
               <Header />
               <Providers>
                 <div
                   className={`flex-grow ${bgColor}`}
-                  style={{ height: "calc(100vh - 56px)" }}
+                  style={{ height: "calc(100svh - 56px)" }}
                 >
                   {children}
                 </div>


### PR DESCRIPTION
### ⚾️ Related Issues

- close #104

### 📝 Task Details

- PC 로컬 IP주소를 통해 모바일 환경에서 로컬 테스트 하였습니다. `http://<PC의 로컬 IP>:3000`
- 모바일 safari 환경에서 스크롤이 생겨 버튼이 안보이는 현상 해결했습니다.
- `vh` 단위는 전체 뷰포트 높이를 기준으로 하는데, 하단 주소창, 툴바 등의 UI 요소들을 viewport의 일부로 인식하여 기존 문제가 발생했습니다. 따라서, 실제로 화면에 보이는 영역을 기준으로 하는 `svh` (small viewport height) 단위로 변경하여 주소창이나 툴바 등을 제외한 공간을 기준으로 뷰포트 높이를 계산하여 문제를 해결할 수 있었습니다. (추가로 `min-h-screen`을 제거하였습니다.)

### 📂 References
<div style="display: flex">
  <img width="300" src="https://github.com/user-attachments/assets/b4552b0f-db2a-4f16-9374-142aa35cb593" />
  <img width="300" src="https://github.com/user-attachments/assets/730ed754-3d09-4bc2-9788-3fe6f13cd7f7" />
</div>



### 💕 Review Requirements

- Please fill out your review request.
