### PR TITLE
feat: 이미지 개수 관련 메세지 text 띄우기

### DIFF
--- a/src/components/gift-upload/GiftForm.tsx
+++ b/src/components/gift-upload/GiftForm.tsx
@@ -120,7 +120,7 @@ const GiftForm = () => {
       <div className="flex flex-col gap-8 mt-[18px] pb-[7px]">
         <div className="flex flex-col gap-[22px]">
           <div
-            className="w-full overflow-x-auto min-w-full flex flex-col gap-1"
+            className="w-full overflow-x-auto min-w-full flex flex-col gap-2"
             style={{ scrollbarWidth: "none" }}
           >
             <UploadImageList

--- a/src/components/gift-upload/GiftForm.tsx
+++ b/src/components/gift-upload/GiftForm.tsx
@@ -117,10 +117,10 @@ const GiftForm = () => {
 
   return (
     <div className="px-4 flex flex-col">
-      <div className="flex flex-col gap-[50px] mt-[18px] pb-[7px]">
+      <div className="flex flex-col gap-8 mt-[18px] pb-[7px]">
         <div className="flex flex-col gap-[22px]">
           <div
-            className="w-full overflow-x-auto min-w-full flex flex-col gap-2"
+            className="w-full overflow-x-auto min-w-full flex flex-col gap-1"
             style={{ scrollbarWidth: "none" }}
           >
             <UploadImageList
@@ -128,6 +128,13 @@ const GiftForm = () => {
               setCombinedImages={setCombinedImages}
               maxImages={5}
             />
+            {combinedImages.length <= 0 ? (
+              <p className="text-xs text-symantic-negative">
+                * 사진은 1장 이상 첨부해 주세요.
+              </p>
+            ) : (
+              <div className="h-4" />
+            )}
           </div>
           <div className="flex flex-col gap-2">
             <CharacterCountInput

--- a/src/components/gift-upload/GiftForm.tsx
+++ b/src/components/gift-upload/GiftForm.tsx
@@ -129,7 +129,7 @@ const GiftForm = () => {
               maxImages={5}
             />
             {combinedImages.length <= 0 ? (
-              <p className="text-xs text-symantic-negative">
+              <p className="text-xs text-coral-400 font-medium">
                 * 사진은 1장 이상 첨부해 주세요.
               </p>
             ) : (


### PR DESCRIPTION
### ⚾️ Related Issues

- close #128 

### 📝 Task Details

- 이미지가 하나도 채워져있지 않을 때 -> 텍스트가 보입니다.
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/b427f6d9-874b-408b-8675-bdedb8ea3430" />

<br/>
<br/>

- 이미지를 1개 이상 채웠을 때
<img width="1470" alt="스크린샷 2025-04-02 오후 7 10 44" src="https://github.com/user-attachments/assets/d3f695ef-eb3b-4ff2-9692-ac3b31ca6b20" />

### 📂 References

- screenshots, GIFs, etc.

### 💕 Review Requirements

- Please fill out your review request.
