### PR TITLE
feat: 선물 박스 채우기 - 이미지 용량 제한 추가

### DIFF
--- a/src/components/gift-upload/GiftForm.tsx
+++ b/src/components/gift-upload/GiftForm.tsx
@@ -114,21 +114,22 @@ const GiftForm = () => {
     router.push("/bundle/add");
   };
 
+  const imageTextColor =
+    combinedImages.length <= 0 ? "text-symantic-negative" : "text-gray-300";
+
   return (
     <div className="flex h-fit w-full flex-col px-4 py-5">
       <div className="flex flex-1 flex-col gap-[22px]">
-        <UploadImageList
-          combinedImages={combinedImages}
-          setCombinedImages={setCombinedImages}
-          maxImages={5}
-        />
-        {combinedImages.length <= 0 ? (
-          <p className="text-xs font-medium text-coral-400">
-            * 사진은 1장 이상 첨부해 주세요.
+        <div className="flex flex-col gap-2">
+          <UploadImageList
+            combinedImages={combinedImages}
+            setCombinedImages={setCombinedImages}
+            maxImages={5}
+          />
+          <p className={`text-xs font-medium ${imageTextColor}`}>
+            최소 1장의 사진이 필요해요 (사진 용량 제한 10MB)
           </p>
-        ) : (
-          <div className="h-4" />
-        )}
+        </div>
         <div className="flex flex-col gap-[50px]">
           <CharacterCountInput
             maxLength={GIFT_NAME_MAX_LENGTH}

--- a/src/components/gift-upload/SortableImageWrapper.tsx
+++ b/src/components/gift-upload/SortableImageWrapper.tsx
@@ -11,6 +11,7 @@ const SortableImageWrapper = ({ id, children }: SortableImageWrapperProps) => {
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
+    display: "inline-block",
   };
 
   const dragHandleProps = { ...attributes, ...listeners };

--- a/src/components/gift-upload/UploadImageList.tsx
+++ b/src/components/gift-upload/UploadImageList.tsx
@@ -5,7 +5,7 @@ import ImageIcon from "../../../public/icons/image_medium.svg";
 import Image from "next/image";
 import { ImageItem } from "@/types/gift-upload/types";
 import { UploadImageListProps } from "@/types/components/types";
-import { IMAGE_EXTENSIONS } from "@/constants/constants";
+import { IMAGE_EXTENSIONS, IMAGE_MAX_SIZE_MB } from "@/constants/constants";
 import { closestCenter, DndContext, DragEndEvent } from "@dnd-kit/core";
 import {
   arrayMove,
@@ -37,10 +37,22 @@ const UploadImageList = ({
         file,
       });
     });
+
+    const oversizedFiles = files.filter(
+      (file) => file.size > IMAGE_MAX_SIZE_MB * 1024 * 1024,
+    );
+
+    if (oversizedFiles.length > 0) {
+      alert("10MB 이하 크기의 이미지만 업로드할 수 있어요!");
+      event.target.value = "";
+      return;
+    }
+
     if (combinedImages.length + newItems.length > maxImages) {
       alert(`최대 ${maxImages}개까지 업로드 가능합니다.`);
       return;
     }
+
     setCombinedImages([...combinedImages, ...newItems]);
     event.target.value = "";
   };
@@ -81,6 +93,7 @@ const UploadImageList = ({
           onChange={handleUpload}
           disabled={combinedImages.length >= maxImages}
           multiple
+          size={10}
         />
       </label>
       <DndContext collisionDetection={closestCenter} onDragEnd={handleDragEnd}>

--- a/src/components/gift-upload/UploadImageList.tsx
+++ b/src/components/gift-upload/UploadImageList.tsx
@@ -96,25 +96,35 @@ const UploadImageList = ({
           size={10}
         />
       </label>
-      <DndContext collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-        <SortableContext
-          items={combinedImages.map((item) => item.url)}
-          strategy={horizontalListSortingStrategy}
+      <div
+        className="flex-1 overflow-x-auto"
+        style={{ scrollbarWidth: "none" }}
+      >
+        <DndContext
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
         >
-          {combinedImages.map((item, index) => (
-            <SortableImageWrapper key={item.url} id={item.url}>
-              {({ dragHandleProps }) => (
-                <ImageCard
-                  src={item.url}
-                  isPrimary={index === 0}
-                  onDelete={() => handleDelete(index)}
-                  dragHandleProps={dragHandleProps}
-                />
-              )}
-            </SortableImageWrapper>
-          ))}
-        </SortableContext>
-      </DndContext>
+          <SortableContext
+            items={combinedImages.map((item) => item.url)}
+            strategy={horizontalListSortingStrategy}
+          >
+            <div className="flex w-max flex-nowrap gap-2">
+              {combinedImages.map((item, index) => (
+                <SortableImageWrapper key={item.url} id={item.url}>
+                  {({ dragHandleProps }) => (
+                    <ImageCard
+                      src={item.url}
+                      isPrimary={index === 0}
+                      onDelete={() => handleDelete(index)}
+                      dragHandleProps={dragHandleProps}
+                    />
+                  )}
+                </SortableImageWrapper>
+              ))}
+            </div>
+          </SortableContext>
+        </DndContext>
+      </div>
     </div>
   );
 };

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -160,3 +160,5 @@ export const ICON_SIZE_MAP: Record<IconSize, number> = {
 };
 
 export const IMAGE_EXTENSIONS = ["jpg", "jpeg", "png", "webp", "heic", "heif"];
+
+export const IMAGE_MAX_SIZE_MB = 10;


### PR DESCRIPTION
### ⚾️ Related Issues

- close #118 

### 📝 Task Details

- 이미지 용량 제한 및 개수와 관련한 text를 구현했습니다.
   - (폰트색상) 이미지 0개: symantic-negative / 이미지 1개 이상: gray-300
<img width="1470" alt="스크린샷 2025-04-09 오후 3 51 34" src="https://github.com/user-attachments/assets/025c9495-e010-4b93-a7a0-26455b0c642c" />
<img width="1470" alt="스크린샷 2025-04-09 오후 3 51 41" src="https://github.com/user-attachments/assets/11a230f3-1ce6-4ed1-a6dc-67ee2f2d99e5" />

<br/>
<br/>

- 10mb를 초과한 이미지를 업로드했을 경우, alert이 뜨도록 처리했습니다. (토스트는 유저 행동의 실패/성공 결과를 알려주거나 api 실패를 알려주는 것으로, 이미지 용량 제한과는 결이 살짝 다르다고 생각해서 alert으로 했는데 경고 토스트가 나을 것 같으면 말씀해주세요)
<img width="1470" alt="스크린샷 2025-04-09 오후 3 51 49" src="https://github.com/user-attachments/assets/32b6480c-ccf3-4b69-93e0-97df646311ee" />

<br/>
<br/>

- 이미지 순서 바꾸기를 하면서 화면 밖으로 이미지들이 튀어나가서 이 부분 수정했습니다. 영상처럼 이미지를 업로드하는 부분은 스크롤이 안되게 하는거 괜찮을까요? 이전에는 그냥 저 부분이 전부 스크롤되어서 이미지를 업로드하는 부분까지 전체가 스크롤이 되고있었습니다.

https://github.com/user-attachments/assets/4c1b0024-4476-47d3-8b84-39572891334b


### 📂 References

- screenshots, GIFs, etc.

### 💕 Review Requirements

- Please fill out your review request.
