### PR TITLE
feat: 선물 박스 삭제/수정 시 토스트 띄우기

### DIFF
--- a/src/app/bundle/add/page.tsx
+++ b/src/app/bundle/add/page.tsx
@@ -1,6 +1,10 @@
 "use client";
 
-import { useEditBoxStore, useGiftStore } from "@/stores/gift-upload/useStore";
+import {
+  useEditBoxStore,
+  useGiftStore,
+  useToastStore,
+} from "@/stores/gift-upload/useStore";
 import Chip from "@/components/bundle/Chip";
 import GiftList from "@/components/bundle/GiftList";
 import { Button } from "@/components/ui/button";
@@ -11,6 +15,7 @@ import { useMutation } from "@tanstack/react-query";
 import { GiftBox } from "@/types/bundle/types";
 import { useEffect } from "react";
 import { MIN_GIFTBOX_AMOUNT } from "@/constants/constants";
+import { toast } from "@/hooks/use-toast";
 
 const Page = () => {
   const { giftBoxes } = useGiftStore();
@@ -26,6 +31,17 @@ const Page = () => {
   useEffect(() => {
     setIsBoxEditing(false);
   }, [setIsBoxEditing]);
+
+  const { showEditToast, setShowEditToast } = useToastStore();
+
+  useEffect(() => {
+    if (showEditToast) {
+      setTimeout(() => {
+        toast({ title: "선물박스 수정이 완료되었어요!" });
+        setShowEditToast(false);
+      }, 200);
+    }
+  }, [setShowEditToast, showEditToast]);
 
   const createMutation = useMutation({
     mutationFn: () =>

--- a/src/components/bundle/GiftList.tsx
+++ b/src/components/bundle/GiftList.tsx
@@ -17,6 +17,7 @@ import {
   GIFTBOX_SHAPE_SEQUENCE,
 } from "@/constants/constants";
 import DeleteBundleDrawer from "../gift-upload/DeleteBundleDrawer";
+import { toast } from "@/hooks/use-toast";
 
 const GiftList = ({ value }: { value: GiftBox[] }) => {
   const router = useRouter();
@@ -46,6 +47,10 @@ const GiftList = ({ value }: { value: GiftBox[] }) => {
     setSelectedBox(null);
     setSelectedIndex(null);
     setDeleteBox(false);
+
+    toast({
+      title: "선물박스를 성공적으로 비웠어요!",
+    });
   };
 
   const [showTooltip, setShowTooltip] = useState(false);

--- a/src/components/gift-upload/GiftForm.tsx
+++ b/src/components/gift-upload/GiftForm.tsx
@@ -13,6 +13,7 @@ import {
   useTagIndexStore,
   useGiftStore,
   useEditBoxStore,
+  useToastStore,
 } from "@/stores/gift-upload/useStore";
 
 import { uploadGiftImages } from "@/api/gift-upload/api";
@@ -111,6 +112,9 @@ const GiftForm = () => {
       });
     }
 
+    if (isBoxEditing) {
+      useToastStore.getState().setShowEditToast(true);
+    }
     router.push("/bundle/add");
   };
 

--- a/src/stores/gift-upload/useStore.ts
+++ b/src/stores/gift-upload/useStore.ts
@@ -56,3 +56,13 @@ export const useEditBoxStore = create<EditBoxStore>()(
     { name: "edit-storage" },
   ),
 );
+
+interface EditToastStore {
+  showEditToast: boolean;
+  setShowEditToast: (val: boolean) => void;
+}
+
+export const useToastStore = create<EditToastStore>((set) => ({
+  showEditToast: false,
+  setShowEditToast: (val) => set({ showEditToast: val }),
+}));


### PR DESCRIPTION
### ⚾️ Related Issues

- close #148 

### 📝 Task Details

- 선물 박스 삭제 시 사진과 같은 토스트가 띄워집니다.
<img width="1147" alt="image" src="https://github.com/user-attachments/assets/7575c906-edef-4b53-8669-db05fac98aa9" />

<br/>
<br/>

- 선물 박스 수정 시 사진과 같은 토스트가 띄워집니다.
<img width="1146" alt="image" src="https://github.com/user-attachments/assets/edb62b2c-5134-4a69-8a03-87f7d93c6c22" />

<br/>
<br/>

- toast같은 경우는 디자이너분들이 디자인을 새로 해주실지 아니면 shadcn을 쓸 지 고민해보신다고 하셨는데, 미리 일단 shadcn 토스트로 구현해두었습니다!
- 혹시 텍스트가 어색하다고 느끼신다면 추천받와요..


### 📂 References

- screenshots, GIFs, etc.

### 💕 Review Requirements

- Please fill out your review request.
