### PR TITLE
fix: 내가 만든 보따리 상세 페이지 로직 수정

### DIFF
--- a/src/app/my-bundles/[bundleId]/page.tsx
+++ b/src/app/my-bundles/[bundleId]/page.tsx
@@ -101,12 +101,16 @@ const Page = () => {
     return 0; // 기본값 0
   };
 
-  const { data: fillGiftData } = useDraftBundleGiftsQuery(parseInt(bundleId));
+  const { refetch: refetchDraftGiftData } = useDraftBundleGiftsQuery(
+    parseInt(bundleId),
+  );
   const fetchSavedGift = async () => {
     if (!bundleId) return;
-    if (!fillGiftData) return;
 
-    const gifts = fillGiftData.gifts;
+    const { data } = await refetchDraftGiftData(); // 수동
+    if (!data) return;
+
+    const gifts = data.gifts;
 
     try {
       const updatePromises = gifts.map(
@@ -224,12 +228,14 @@ const Page = () => {
               </Button>
             </div>
           ) : (
-            <Button
-              size="lg"
-              onClick={() => router.push(`/my-bundles/${bundleId}/answer`)}
-            >
-              답변 확인하기
-            </Button>
+            status === "COMPLETED" && (
+              <Button
+                size="lg"
+                onClick={() => router.push(`/my-bundles/${bundleId}/answer`)}
+              >
+                답변 확인하기
+              </Button>
+            )
           )}
         </div>
       </div>

--- a/src/queries/useDraftBundleGiftsQuery.ts
+++ b/src/queries/useDraftBundleGiftsQuery.ts
@@ -6,5 +6,6 @@ export const useDraftBundleGiftsQuery = (bundleId: number) => {
   return useQuery({
     queryKey: ["draftBundle"],
     queryFn: () => getDraftBundleGifts(bundleId),
+    enabled: false,
   });
 };


### PR DESCRIPTION
### ⚾️ Related Issues

- close #[issue_number]

### 📝 Task Details

- 병합하다가 빠진 로직 수정 (답변이 완료된 보따리에만 답변 확인하기 버튼 보이도록)
- 내가 만든 보따리 상세 페이지에서 마저 채우기 버튼 클릭 시에 불러오는 임시 저장된 보따리 데이터를 상세 페이지 진입 시 자동으로 불러오고 있어서 상세 페이지 진입 시 계속 401 에러가 났습니다. (답변 대기, 답변 완료에도 임시 저장된 보따리를 fetch하려고 해서) 따라서, 임시 저장된 보따리의 경우에서 마저 채우기 버튼 클릭 시에만 불러오도록 수동으로 fetch 하는 로직으로 수정하였습니다.

### 📂 References

- screenshots, GIFs, etc.

### 💕 Review Requirements

- Please fill out your review request.
