### PR TITLE
feat: accessToken 재발급 로직 및 자동 로그아웃

### DIFF
--- a/src/api/axiosInstance.ts
+++ b/src/api/axiosInstance.ts
@@ -1,5 +1,8 @@
 import axios from "axios";
-import { getCookie } from "cookies-next";
+import { getCookie, setCookie } from "cookies-next";
+
+import { toast } from "@/hooks/use-toast";
+import { deleteToken } from "@/utils/utils";
 
 const axiosInstance = axios.create({
   baseURL: `${process.env.NEXT_PUBLIC_API_BASE_PATH}`,
@@ -8,11 +11,77 @@ const axiosInstance = axios.create({
   },
 });
 
-const token = getCookie("accessToken");
+const accessToken = getCookie("accessToken");
 
 // accessToken이 있다면 기본 헤더에 Authorization 설정
-if (token) {
-  axiosInstance.defaults.headers.Authorization = `Bearer ${token}`;
+if (accessToken) {
+  axiosInstance.defaults.headers.Authorization = `Bearer ${accessToken}`;
 }
+
+// accessToken 만료 시 refreshToken으로 재발급
+axiosInstance.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config;
+
+    // accessToken이 만료되어 401을 받은 경우
+    if (
+      error.response?.status === 401 &&
+      !originalRequest._retry // 무한루프 방지용 flag
+    ) {
+      originalRequest._retry = true;
+
+      console.log("accessToken이 만료되었습니다.", error);
+
+      try {
+        const refreshToken = getCookie("refreshToken");
+
+        if (!refreshToken) {
+          console.log("refreshToken 없음. 로그아웃.", refreshToken);
+          deleteToken();
+          toast({ title: "다시 로그인해 주세요." });
+          return (window.location.href = "/auth/login");
+        }
+
+        // refreshToken으로 accessToken 재발급 요청
+        const res = await axios.post(
+          `${process.env.NEXT_PUBLIC_API_BASE_PATH}/auth/refresh`,
+          {
+            refreshToken, // body
+          },
+          {
+            headers: {
+              "Content-Type": "application/json",
+            },
+          },
+        );
+
+        console.log("재발급 요청에 성공하였습니다.", res.data);
+
+        const newAccessToken = res.data.result.accessToken;
+        const newRefreshToken = res.data.result.refreshToken;
+
+        // 새 accessToken 저장
+        setCookie("accessToken", newAccessToken);
+        setCookie("refreshToken", newRefreshToken);
+
+        console.log("저장 완료! 재요청합니다.");
+
+        // 원래 요청에 새 accessToken 넣어서 재요청
+        originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+        return axiosInstance(originalRequest);
+      } catch (refreshError) {
+        console.log("refreshToken 오류", refreshError);
+
+        deleteToken(); // 로그아웃
+        toast({ title: "장기간 사용하지 않아 로그아웃 되었습니다." });
+
+        return (window.location.href = "/auth/login");
+      }
+    }
+
+    return Promise.reject(error);
+  },
+);
 
 export default axiosInstance;


### PR DESCRIPTION
### ⚾️ Related Issues

- close #76

### 📝 Task Details

- API 요청할 때, accessToken이 만료되어 401 Unauthorized을 받은 경우, 이때 interceptor가 동작하여 refreshToken을 통해 accessToken과 refreshToken을 재발급하여 재요청할 수 있도록 했습니다.
- 위 재발급 요청에서도 refreshToken이 만료되면 자동으로 `deleteToken`을 통해 로그아웃 되고, `/auth/login`으로 이동하도록 구현해두었습니다. 

### 📂 References

- screenshots, GIFs, etc.

### 💕 Review Requirements

- 가끔 처음에? 카카오 로그인 하자마자 setToken으로 accessToken이랑 refreshToken 저장하는데도, `/home`에서 보따리 프리뷰 데이터 불러오려고 하면 refreshToken이 없다고 떠서 로그아웃 처리가 되더라고요 🤔🥹
- 가끔 API 요청할 때마다 accessToken이 만료됐다고 떠서 재발급을 받게 되는데 이거는 accessToken이 길어지면 문제가 없을 것으로 예상..합니다
- console.log는 추후 계속해서 테스트가 필요할 것 같아서 일단 제거하지 않겠습니다!
