### PR TITLE
fix: Image 태그 관련 warning 해결

### DIFF
--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -52,8 +52,8 @@ const Page = () => {
               src={MainGraphic}
               alt="MainGraphic"
               width={430}
-              height={396}
-              loading="eager"
+              style={{ height: "auto" }}
+              priority
               className="absolute bottom-0"
             />
           </div>

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -26,9 +26,9 @@ const Page = () => {
         <Image
           src={MainGraphic}
           alt="MainGraphic"
-          width={394}
-          height={346}
-          loading="eager"
+          width={430}
+          style={{ height: "auto" }}
+          priority
         />
         <Link
           href="/bundle/select"

--- a/src/components/bundle/GiftList.tsx
+++ b/src/components/bundle/GiftList.tsx
@@ -107,8 +107,8 @@ const GiftList = ({ value }: { value: GiftBox[] }) => {
                           src={imageSrc}
                           alt={`gift-item-${index}`}
                           className="h-full w-full object-contain hover:opacity-[75%]"
-                          width="130"
-                          height="130"
+                          width={130}
+                          height={130}
                         />
                       </div>
                     </DrawerTrigger>
@@ -139,8 +139,8 @@ const GiftList = ({ value }: { value: GiftBox[] }) => {
                             src={GIFTBOX_DEFAULT_IMAGES[index % 2]}
                             alt={`gift-item-${index}`}
                             className="h-full w-full object-contain hover:opacity-[75%]"
-                            width="130"
-                            height="130"
+                            width={130}
+                            height={130}
                           />
                         </TooltipTrigger>
                         <TooltipContent
@@ -156,8 +156,8 @@ const GiftList = ({ value }: { value: GiftBox[] }) => {
                         src={imageSrc}
                         alt={`gift-item-${index}`}
                         className="h-full w-full object-contain hover:opacity-[75%]"
-                        width="130"
-                        height="130"
+                        width={130}
+                        height={130}
                       />
                     )}
                   </div>

--- a/src/components/bundle/SelectedBundle.tsx
+++ b/src/components/bundle/SelectedBundle.tsx
@@ -24,8 +24,8 @@ const SelectedBundle = () => {
           src={BUNDLE_IMAGE_PATHS[selectedBagIndex % BUNDLE_IMAGE_PATHS.length]}
           alt={`Gift Bag ${selectedBagIndex}`}
           className="h-full w-full"
-          width="200"
-          height="200"
+          width={200}
+          height={200}
         />
       )}
     </div>

--- a/src/components/common/Card.tsx
+++ b/src/components/common/Card.tsx
@@ -43,6 +43,7 @@ const Card = ({
         width={imageSize}
         height={imageSize}
         className="h-full w-full rounded-xl object-cover"
+        priority
       />
       <div className="absolute right-2 top-2">
         {isRead === false && <Image src={IndicatorIcon} alt="IndicatorIcon" />}

--- a/src/components/common/Icon.tsx
+++ b/src/components/common/Icon.tsx
@@ -21,6 +21,7 @@ export const Icon = ({
       height={pixelSize}
       className={className}
       loading={loading}
+      priority
     />
   );
 };

--- a/src/components/common/Onboarding.tsx
+++ b/src/components/common/Onboarding.tsx
@@ -20,8 +20,8 @@ const Onboarding = ({ onComplete }: { onComplete: () => void }) => {
         src={MainGraphic}
         alt="MainGraphic"
         width={430}
-        height={396}
-        loading="eager"
+        style={{ height: "auto" }}
+        priority
       />
 
       <div className="absolute bottom-4 w-full px-4">


### PR DESCRIPTION
### ⚾️ Related Issues

- close #[issue_number]

### 📝 Task Details

> ...was detected as the Largest Contentful Paint (LCP). Please add the "priority" property if this image is above the fold.

- 초기 렌더에서 사용자에게 가장 크게 보이는 요소라서, Next.js가 이걸 LCP 요소로 인식하는데,  `priority` 속성이 빠져있어 위 경고가 떴습니다. `priority` 속성을 추가하였습니다.

> ....has either width or height modified, but not the other. If you use CSS to change the size of your image, also include the styles 'width: "auto"' or 'height: "auto"' to maintain the aspect ratio.

- Image가 내부적으로 비율을 정확히 못 맞춘다고 판단하여 위 경고를 띄웠습니다. `height`를 `auto`로 명시하였습니다.



### 📂 References

- screenshots, GIFs, etc.

### 💕 Review Requirements

- Please fill out your review request.
