### PR TITLE
style: 답변 페이지 재퍼블리싱

### DIFF
--- a/src/app/bundle/[id]/page.tsx
+++ b/src/app/bundle/[id]/page.tsx
@@ -55,8 +55,8 @@ const Page = () => {
     <div className={`relative h-full ${step === "2" && "bg-pink-50"}`}>
       {step === "1" && (
         <Step1
-          delivery={bundle.delivery_character_type}
-          color={bundle.design_type.toLowerCase()}
+          delivery={bundle.deliveryCharacterType}
+          color={bundle.designType.toLowerCase()}
           isCompleted={bundle.status === "COMPLETED"}
         />
       )}
@@ -67,7 +67,7 @@ const Page = () => {
           isCompleted={bundle.status === "COMPLETED"}
         />
       )}
-      {step === "3" && <Step3 delivery={bundle.delivery_character_type} />}
+      {step === "3" && <Step3 delivery={bundle.deliveryCharacterType} />}
     </div>
   );
 };

--- a/src/app/bundle/[id]/step2.tsx
+++ b/src/app/bundle/[id]/step2.tsx
@@ -83,7 +83,9 @@ const Step2 = ({ gifts, giftResultData, isCompleted }: Step2Props) => {
   const bgColor = isOpenDetailGiftBox ? "bg-gray-100" : "bg-pink-50";
 
   return (
-    <div className={`relative h-full overflow-hidden ${bgColor}`}>
+    <div
+      className={`relative h-full overflow-y-auto overflow-x-hidden ${bgColor}`}
+    >
       {isOpenDetailGiftBox ? (
         <DetailGiftBox giftList={gifts} mappedAnswers={mappedAnswers} />
       ) : (

--- a/src/components/bundle/CarouselNavigator.tsx
+++ b/src/components/bundle/CarouselNavigator.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+import { ReceiveGiftBox } from "@/types/bundle/types";
+
+const CarouselNavigator = ({
+  giftList,
+  currentCarousel,
+}: {
+  giftList: ReceiveGiftBox[];
+  currentCarousel: number;
+}) => {
+  return (
+    <div className="flex flex-row gap-2">
+      {giftList.map((_, index) => {
+        return (
+          <p
+            className={`h-[6px] w-[6px] rounded-full ${
+              currentCarousel === index + 1 ? "bg-pink-500" : "bg-gray-300"
+            }`}
+            key={index}
+          ></p>
+        );
+      })}
+    </div>
+  );
+};
+
+export default CarouselNavigator;

--- a/src/components/bundle/CarouselNavigator.tsx
+++ b/src/components/bundle/CarouselNavigator.tsx
@@ -10,7 +10,7 @@ const CarouselNavigator = ({
   currentCarousel: number;
 }) => {
   return (
-    <div className="flex flex-row gap-2">
+    <div className="flex h-4 flex-row items-center gap-2">
       {giftList.map((_, index) => {
         return (
           <p

--- a/src/components/bundle/DetailGiftBox.tsx
+++ b/src/components/bundle/DetailGiftBox.tsx
@@ -18,6 +18,7 @@ import RightIcon from "/public/icons/arrow_right_large.svg";
 import { useSelectedGiftBoxStore } from "@/stores/bundle/useStore";
 import { DetailGiftBoxProps } from "@/types/components/types";
 
+import CarouselNavigator from "./CarouselNavigator";
 import ReceiveAnswerChipList from "./ReceiveAnswerChipList";
 
 const DetailGiftBox = ({ giftList, mappedAnswers }: DetailGiftBoxProps) => {
@@ -70,100 +71,94 @@ const DetailGiftBox = ({ giftList, mappedAnswers }: DetailGiftBoxProps) => {
   };
 
   return (
-    <div className="flex h-full flex-col items-center justify-center gap-6">
-      <div className="mt-[17px] flex gap-2">
-        {giftList.map((_, index) => {
-          return (
-            <p
-              className={`h-[6px] w-[6px] rounded-full ${
-                currentCarousel === index + 1 ? "bg-pink-500" : "bg-gray-300"
-              }`}
-              key={index}
-            ></p>
-          );
-        })}
-      </div>
-      <Carousel className="w-[304px]" setApi={setCarouselApi}>
-        <CarouselContent className="gap-4 pb-0">
-          {giftList.map((gift, giftIndex) => {
-            return (
-              <CarouselItem
-                key={giftIndex}
-                className="flex h-[379px] w-[287px] flex-col overflow-hidden rounded-[22px] bg-white"
-              >
-                <div className="-mx-4">
-                  <Carousel
-                    setApi={(api) => {
-                      imgCarouselApis.current[giftIndex] = api;
-                      api?.on("select", () =>
-                        handleImageCarouselSelect(giftIndex),
-                      );
-                    }}
-                    opts={{ watchDrag: false }}
-                  >
-                    <CarouselContent className="flex">
-                      {gift.imageUrls.map((url, index) => {
-                        return (
-                          <CarouselItem
-                            key={index}
-                            className="relative h-[236px]"
-                          >
-                            <Image
-                              src={url}
-                              alt={`image_${index}`}
-                              layout="fill"
-                              objectFit="cover"
-                              className="pointer-events-none rounded-t-[22px]"
-                            />
-                          </CarouselItem>
+    <div className="flex h-full flex-col items-center justify-center gap-12">
+      <div className="flex flex-col items-center justify-center gap-6">
+        <CarouselNavigator
+          giftList={giftList}
+          currentCarousel={currentCarousel}
+        />
+        <Carousel className="w-[304px]" setApi={setCarouselApi}>
+          <CarouselContent className="gap-4 pb-0">
+            {giftList.map((gift, giftIndex) => {
+              return (
+                <CarouselItem
+                  key={giftIndex}
+                  className="flex h-[379px] w-[287px] flex-col overflow-hidden rounded-[22px] bg-white"
+                >
+                  <div className="-mx-4">
+                    <Carousel
+                      setApi={(api) => {
+                        imgCarouselApis.current[giftIndex] = api;
+                        api?.on("select", () =>
+                          handleImageCarouselSelect(giftIndex),
                         );
-                      })}
-                    </CarouselContent>
-                    {currentImageIndexes[giftIndex] !== 0 && (
-                      <Button
-                        className="absolute left-2 top-1/2 h-7 w-7 -translate-y-1/2 transform rounded-full bg-gray-100 opacity-30 hover:opacity-60"
-                        onClick={() => handlePrevImage(giftIndex)}
-                        disabled={currentImageIndexes[giftIndex] === 0}
-                        variant="ghost"
-                      >
-                        <Icon src={LeftIcon} alt="leftArrow" size="small" />
-                      </Button>
-                    )}
-                    {currentImageIndexes[giftIndex] !==
-                      gift.imageUrls.length - 1 && (
-                      <Button
-                        className="absolute right-2 top-1/2 h-7 w-7 -translate-y-1/2 transform rounded-full bg-gray-100 opacity-30 hover:opacity-60"
-                        onClick={() => handleNextImage(giftIndex)}
-                        disabled={
-                          currentImageIndexes[giftIndex] ===
-                          gift.imageUrls.length - 1
-                        }
-                        variant="ghost"
-                      >
-                        <Icon src={RightIcon} alt="RightArrow" size="small" />
-                      </Button>
-                    )}
-                    <div className="absolute bottom-2 right-2 h-[23px] w-10 rounded-[40px] bg-white/70 px-[10px] py-1 text-center">
-                      <p className="text-[10px] tracking-[2px] text-gray-600">
-                        {currentImageIndexes[giftIndex] + 1}/
-                        {gift.imageUrls.length}
-                      </p>
-                    </div>
-                  </Carousel>
-                </div>
-                <div className="mt-[9px] flex flex-col gap-[10px]">
-                  <p className="text-base font-bold text-gray-500">
-                    {gift.name}
-                  </p>
-                  <p className="text-[13px] tracking-[-0.13px]">
-                    {gift.message}
-                  </p>
-                </div>
-              </CarouselItem>
-            );
-          })}
-        </CarouselContent>
-      </Carousel>
+                      }}
+                      opts={{ watchDrag: false }}
+                    >
+                      <CarouselContent className="flex">
+                        {gift.imageUrls.map((url, index) => {
+                          return (
+                            <CarouselItem
+                              key={index}
+                              className="relative h-[236px]"
+                            >
+                              <Image
+                                src={url}
+                                alt={`image_${index}`}
+                                layout="fill"
+                                objectFit="cover"
+                                className="pointer-events-none rounded-t-[22px]"
+                              />
+                            </CarouselItem>
+                          );
+                        })}
+                      </CarouselContent>
+                      {currentImageIndexes[giftIndex] !== 0 && (
+                        <Button
+                          className="absolute left-2 top-1/2 h-7 w-7 -translate-y-1/2 transform rounded-full bg-gray-100 opacity-30 hover:opacity-60"
+                          onClick={() => handlePrevImage(giftIndex)}
+                          disabled={currentImageIndexes[giftIndex] === 0}
+                          variant="ghost"
+                        >
+                          <Icon src={LeftIcon} alt="leftArrow" size="small" />
+                        </Button>
+                      )}
+                      {currentImageIndexes[giftIndex] !==
+                        gift.imageUrls.length - 1 && (
+                        <Button
+                          className="absolute right-2 top-1/2 h-7 w-7 -translate-y-1/2 transform rounded-full bg-gray-100 opacity-30 hover:opacity-60"
+                          onClick={() => handleNextImage(giftIndex)}
+                          disabled={
+                            currentImageIndexes[giftIndex] ===
+                            gift.imageUrls.length - 1
+                          }
+                          variant="ghost"
+                        >
+                          <Icon src={RightIcon} alt="RightArrow" size="small" />
+                        </Button>
+                      )}
+                      <div className="absolute bottom-2 right-2 h-[23px] w-10 rounded-[40px] bg-white/70 px-[10px] py-1 text-center">
+                        <p className="text-[10px] tracking-[2px] text-gray-600">
+                          {currentImageIndexes[giftIndex] + 1}/
+                          {gift.imageUrls.length}
+                        </p>
+                      </div>
+                    </Carousel>
+                  </div>
+                  <div className="mt-[9px] flex flex-col gap-[10px]">
+                    <p className="text-base font-bold text-gray-500">
+                      {gift.name}
+                    </p>
+                    <p className="text-[13px] tracking-[-0.13px]">
+                      {gift.message}
+                    </p>
+                  </div>
+                </CarouselItem>
+              );
+            })}
+          </CarouselContent>
+        </Carousel>
+      </div>
       {giftList.length > 0 && currentCarousel > 0 && (
         <ReceiveAnswerChipList
           mappedAnswers={mappedAnswers}

--- a/src/components/bundle/DetailGiftBox.tsx
+++ b/src/components/bundle/DetailGiftBox.tsx
@@ -71,7 +71,7 @@ const DetailGiftBox = ({ giftList, mappedAnswers }: DetailGiftBoxProps) => {
   };
 
   return (
-    <div className="flex h-full flex-col items-center justify-center gap-12">
+    <div className="flex h-fit flex-col items-center justify-center gap-16 pt-8">
       <div className="flex flex-col items-center justify-center gap-6">
         <CarouselNavigator
           giftList={giftList}

--- a/src/components/bundle/DetailGiftBox.tsx
+++ b/src/components/bundle/DetailGiftBox.tsx
@@ -78,7 +78,7 @@ const DetailGiftBox = ({ giftList, mappedAnswers }: DetailGiftBoxProps) => {
           currentCarousel={currentCarousel}
         />
         <Carousel className="w-[304px]" setApi={setCarouselApi}>
-          <CarouselContent className="gap-4 pb-0">
+          <CarouselContent className="gap-7 pb-0">
             {giftList.map((gift, giftIndex) => {
               return (
                 <CarouselItem

--- a/src/components/bundle/ReceiveAnswerChip.tsx
+++ b/src/components/bundle/ReceiveAnswerChip.tsx
@@ -9,7 +9,7 @@ const ReceiveAnswerChip = ({
   return (
     <span
       onClick={!disabled ? onClick : undefined}
-      className={`justify-left inline-flex h-[39px] min-w-[164px] items-center rounded-[6px] border-[1.4px] border-[#E9EBF880] px-3 ${!disabled && "cursor-pointer"} ${isActive ? "bg-pink-400 text-white" : ` ${!disabled ? "bg-white hover:bg-pink-400 hover:text-white" : "text-black"}`}`}
+      className={`justify-left inline-flex h-[39px] min-w-[164px] items-center rounded-[6px] border-[1.4px] border-[#E9EBF880] px-3 ${!disabled && "cursor-pointer"} ${isActive ? "bg-pink-400 text-white" : ` ${!disabled ? "bg-white hover:bg-pink-400 hover:text-white" : "bg-gray-50 text-gray-300"}`}`}
     >
       <p className="m-0 text-[15px]">{text}</p>
     </span>

--- a/src/types/bundle/types.ts
+++ b/src/types/bundle/types.ts
@@ -15,10 +15,10 @@ export interface GiftBox {
 export interface ReceiveBundle {
   id: number;
   status: string;
-  delivery_character_type: string;
-  design_type: string;
+  deliveryCharacterType: string;
+  designType: string;
   gifts: ReceiveGiftBox[];
-  total_gifts: number;
+  totalGifts: number;
 }
 
 export interface ReceiveGiftBox {


### PR DESCRIPTION
### ⚾️ Related Issues

- close #182 

### 📝 Task Details

- 예전에 현상님께서 api res를 다시 snake case에서 camel case로 바꾸셨다고 했던 부분 수정하였습니다.

<br/>
<br/>

- 답변 페이지 레이아웃을 조금씩 바꾸었습니다. (margin, padding 값 같은)
- 해당 페이지에서의 header의 디자인을 수정했습니다. (불필요한 코드 정리)

<br/>
<br/>

- 웹 및 대부분의 모바일에서 보이는 화면
<img width="1470" alt="스크린샷 2025-04-28 오후 8 07 17" src="https://github.com/user-attachments/assets/f8319388-0dd0-4226-a1b7-84400f882642" />

<br/>
<br/>


- 아이폰 se의 기종과 같이 화면이 작을 때 (선물이름에 배경이 회색인건 무시해주세요,, 마우스로 text 선택해놔서 그렇게 보이는거에요!!)
<img width="963" alt="스크린샷 2025-04-28 오후 8 07 34" src="https://github.com/user-attachments/assets/c7f06e98-e27b-433a-8ce3-500decf1da22" />

<br/>
<br/>

- 답변 완료 시 답변 태그 chip의 배경과 글씨 색을 바꾸어 자신이 선택했던 답변만 강조시켰습니다.
<img width="1470" alt="스크린샷 2025-04-28 오후 8 08 27" src="https://github.com/user-attachments/assets/0b1b2b42-41cb-488c-9f0e-3d7fd2565fbc" />



### 📂 References


### 💕 Review Requirements

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/2fbb02f9-1d35-4d70-b119-bcf274605fa1" />

-> carousel navigation (현재 케러셀 페이지를 나타내주는 상단 점들)이 피그마에서는 헤더에 위치해있는데, 그렇게 되면 전달해줘야하는 props가 너무 복잡해져서 지금과 같이 헤더 밑에 위치해있어야 할 것 같아요. 

그래서 생각해본것: 사용자들이 해당 페이지에서 무엇을 해야하는지 잘 모르겠다고 말함 
=> 헤더에 사진과 같이 text를 넣어보았는데 이러면 조금 직관적인 것 같아서 어떻게 생각하세요? 회의에서도 말해봐야할 것 같아요.