### PR TITLE
feat: 상세 페이지 헤더에 보따리 이름 표시

### DIFF
--- a/src/app/bundle/delivery/step2.tsx
+++ b/src/app/bundle/delivery/step2.tsx
@@ -7,7 +7,7 @@ import { Fragment } from "react";
 import { Button } from "@/components/ui/button";
 import { CHARACTERS, DELIVERY_CHARACTER_MAP } from "@/constants/constants";
 import { useDeliveryCharacterMutation } from "@/queries/useDeliveryCharacterMutation";
-import { useBundleStore } from "@/stores/bundle/useStore";
+import { useBundleNameStore } from "@/stores/bundle/useStore";
 import { CharacterKey } from "@/types/constants/types";
 import { resetGiftBoxes } from "@/utils/giftBoxUtils";
 
@@ -23,7 +23,7 @@ const Step2 = () => {
 
   const characterKey = (characterEntry?.[0] ?? "CHARACTER_1") as CharacterKey;
 
-  const { setBundleName } = useBundleStore();
+  const { setBundleName } = useBundleNameStore();
 
   const resetStore = () => {
     resetGiftBoxes();

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -53,11 +53,12 @@ export default function RootLayout({
       <body
         className={`${pretendard.variable} ${nanumSquareRound.variable} antialiased`}
       >
-        <div className="relative mx-auto flex min-w-[375px] max-w-[430px] flex-col">
-          <Suspense>
-            <PageTransition>
-              <Header />
-              <Providers>
+        <Providers>
+          <div className="relative mx-auto flex min-w-[375px] max-w-[430px] flex-col">
+            <Suspense>
+              <PageTransition>
+                <Header />
+
                 <div
                   className={`flex-grow ${bgColor}`}
                   style={{ height: "calc(100svh - 56px)" }}
@@ -65,11 +66,11 @@ export default function RootLayout({
                   {children}
                 </div>
                 <Toaster />
-              </Providers>
-            </PageTransition>
-          </Suspense>
-        </div>
-        <KakaoInitScript />
+              </PageTransition>
+            </Suspense>
+          </div>
+          <KakaoInitScript />
+        </Providers>
       </body>
     </html>
   );

--- a/src/app/my-bundles/[bundleId]/page.tsx
+++ b/src/app/my-bundles/[bundleId]/page.tsx
@@ -23,7 +23,7 @@ import { useDeleteMyBundleMutation } from "@/queries/useDeleteMyBundleMutation";
 import { useDraftBundleGiftsQuery } from "@/queries/useDraftBundleGiftsQuery";
 import { useMyBundleDetailQuery } from "@/queries/useMyBundleDetailQuery";
 import {
-  useBundleStore,
+  useBundleNameStore,
   useIsClickedUpdateFilledButton,
 } from "@/stores/bundle/useStore";
 import { useGiftStore } from "@/stores/gift-upload/useStore";
@@ -36,7 +36,7 @@ const Page = () => {
   const router = useRouter();
   const { bundleId } = useParams() as { bundleId: string };
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
-  const { setBundleName } = useBundleStore();
+  const { setBundleName } = useBundleNameStore();
 
   const { updateGiftBox } = useGiftStore();
 

--- a/src/app/my-bundles/[bundleId]/page.tsx
+++ b/src/app/my-bundles/[bundleId]/page.tsx
@@ -21,7 +21,10 @@ import { useDeleteMyBundleMutation } from "@/queries/useDeleteMyBundleMutation";
 import { useMyBundleDetailQuery } from "@/queries/useMyBundleDetailQuery";
 import { toast } from "@/hooks/use-toast";
 import { useDraftBundleGiftsQuery } from "@/queries/useDraftBundleGiftsQuery";
-import { useIsClickedUpdateFilledButton } from "@/stores/bundle/useStore";
+import {
+  useBundleStore,
+  useIsClickedUpdateFilledButton,
+} from "@/stores/bundle/useStore";
 import { useGiftStore } from "@/stores/gift-upload/useStore";
 import { DESIGN_TYPE_MAP } from "@/constants/constants";
 import { resetGiftBoxes } from "@/utils/utils";
@@ -32,17 +35,24 @@ const Page = () => {
   const router = useRouter();
   const { bundleId } = useParams() as { bundleId: string };
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const { setBundleName } = useBundleStore();
 
   const { updateGiftBox } = useGiftStore();
 
   const { data } = useMyBundleDetailQuery(parseInt(bundleId));
-  const { designType, link, status, gifts } = data?.result || {
+  const { name, designType, link, status, gifts } = data?.result || {
     name: "",
     designType: "",
     link: "",
     status: "",
     gifts: [],
   };
+
+  useEffect(() => {
+    if (name) {
+      setBundleName(name);
+    }
+  }, [name]);
 
   const { setIsClickedUpdateFilledButton } = useIsClickedUpdateFilledButton();
 
@@ -51,6 +61,7 @@ const Page = () => {
   }, [setIsClickedUpdateFilledButton]);
 
   const { mutate: deleteBundle } = useDeleteMyBundleMutation();
+
   const handleDelete = () => {
     if (!bundleId) return;
 

--- a/src/app/my-bundles/[bundleId]/page.tsx
+++ b/src/app/my-bundles/[bundleId]/page.tsx
@@ -36,7 +36,7 @@ const Page = () => {
   const router = useRouter();
   const { bundleId } = useParams() as { bundleId: string };
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
-  
+
   const { setBundleName } = useBundleNameStore();
   const { updateGiftBox } = useGiftStore();
 

--- a/src/components/bundle/BundleForm.tsx
+++ b/src/components/bundle/BundleForm.tsx
@@ -5,10 +5,10 @@ import Link from "next/link";
 import CharacterCountInput from "@/components/common/CharacterCountInput";
 import { Button } from "@/components/ui/button";
 import { BUNDLE_NAME_MAX_LENGTH } from "@/constants/constants";
-import { useBundleStore } from "@/stores/bundle/useStore";
+import { useBundleNameStore } from "@/stores/bundle/useStore";
 
 const BundleForm = () => {
-  const { bundleName, setBundleName } = useBundleStore();
+  const { bundleName, setBundleName } = useBundleNameStore();
 
   return (
     <div className="flex w-full flex-col items-center gap-[57px]">

--- a/src/hooks/useDynamicTitle.ts
+++ b/src/hooks/useDynamicTitle.ts
@@ -1,12 +1,12 @@
 import { useSearchParams, usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
 
-import { useBundleStore, useGiftNameStore } from "@/stores/bundle/useStore";
+import { useBundleNameStore, useGiftNameStore } from "@/stores/bundle/useStore";
 
 const useDynamicTitle = () => {
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const { bundleName } = useBundleStore();
+  const { bundleName } = useBundleNameStore();
   const { giftName } = useGiftNameStore();
 
   const [dynamicTitle, setDynamicTitle] = useState("");

--- a/src/hooks/useDynamicTitle.ts
+++ b/src/hooks/useDynamicTitle.ts
@@ -1,4 +1,4 @@
-import { useSearchParams, useParams, usePathname } from "next/navigation";
+import { useSearchParams, usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
 
 import { useBundleStore, useGiftNameStore } from "@/stores/bundle/useStore";
@@ -6,39 +6,36 @@ import { useBundleStore, useGiftNameStore } from "@/stores/bundle/useStore";
 const useDynamicTitle = () => {
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const { giftId } = useParams() as { giftId?: string };
   const { bundleName } = useBundleStore();
   const { giftName } = useGiftNameStore();
 
   const [dynamicTitle, setDynamicTitle] = useState("");
 
+  const singleDetailRegex = /^\/my-bundles\/\d+\/?$/;
+  const nestedDetailRegex = /^\/my-bundles\/\d+\/\d+$/;
+
   useEffect(() => {
-    if (giftName && giftId) {
+    if (bundleName && singleDetailRegex.test(pathname)) {
+      setDynamicTitle(bundleName);
+    } else if (giftName && nestedDetailRegex.test(pathname)) {
       setDynamicTitle(giftName);
     } else if (bundleName && pathname === "/bundle/add") {
       setDynamicTitle(bundleName);
     } else {
-      const title = searchParams?.get("title");
-      if (title) {
-        setDynamicTitle(title);
-      } else {
-        const pageTitles: { [key: string]: string } = {
-          "/Bundle/detail": "내가 만든 보따리",
-          "/Bundle/list": "내가 만든 보따리",
-          "/Bundle/delivery": "선물 보따리 배달하기",
-          "/Bundle": "선물 보따리 만들기",
-          "/gift-upload": "선물 박스 채우기",
-          "/setting/account": "연결된 계정",
-          "/setting/notice": "공지사항",
-          "/setting": "설정",
-        };
-        const matchedTitle = Object.keys(pageTitles).find((key) =>
-          pathname?.includes(key),
-        );
-        setDynamicTitle(matchedTitle ? pageTitles[matchedTitle] : "PICKTORY");
-      }
+      const pageTitles: { [path: string]: string } = {
+        "/bundle/delivery": "선물 보따리 배달하기",
+        "/bundle": "선물 보따리 만들기",
+        "/gift-upload": "선물 박스 채우기",
+        "/setting/account": "연결된 계정",
+        "/setting/notice": "공지사항",
+        "/setting": "설정",
+      };
+      const matchedTitle = Object.keys(pageTitles).find((path) =>
+        pathname?.includes(path),
+      );
+      setDynamicTitle(matchedTitle ? pageTitles[matchedTitle] : "PICKTORY");
     }
-  }, [pathname, giftId, giftName, bundleName, searchParams]);
+  }, [pathname, giftName, bundleName, searchParams]);
 
   return dynamicTitle;
 };

--- a/src/hooks/useResetStore.ts
+++ b/src/hooks/useResetStore.ts
@@ -2,14 +2,14 @@ import { useEffect } from "react";
 
 import {
   useSelectedBagStore,
-  useBundleStore,
+  useBundleNameStore,
   useIsClickedUpdateFilledButton,
 } from "@/stores/bundle/useStore";
 import { resetGiftBoxes } from "@/utils/giftBoxUtils";
 
 const useResetStore = () => {
   const { setSelectedBagIndex } = useSelectedBagStore();
-  const { setBundleName } = useBundleStore();
+  const { setBundleName } = useBundleNameStore();
   const { setIsClickedUpdateFilledButton } = useIsClickedUpdateFilledButton();
 
   useEffect(() => {

--- a/src/layout/GoToHomeDrawer.tsx
+++ b/src/layout/GoToHomeDrawer.tsx
@@ -14,11 +14,14 @@ import {
 import CloseIcon from "/public/icons/close.svg";
 
 import { useTempSaveBundle } from "@/hooks/useTempSaveBundle";
-import { useBundleStore, useSelectedBagStore } from "@/stores/bundle/useStore";
+import {
+  useBundleNameStore,
+  useSelectedBagStore,
+} from "@/stores/bundle/useStore";
 import { GoToHomeDrawerProps } from "@/types/bundle/types";
 
 const GoToHomeDrawer = ({ open, onClose, onConfirm }: GoToHomeDrawerProps) => {
-  const { bundleName } = useBundleStore();
+  const { bundleName } = useBundleNameStore();
   const { selectedBagIndex } = useSelectedBagStore();
 
   const { handleTempSave } = useTempSaveBundle();

--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -20,7 +20,7 @@ import {
 import useDynamicTitle from "@/hooks/useDynamicTitle";
 import { useTempSaveBundle } from "@/hooks/useTempSaveBundle";
 import {
-  useBundleStore,
+  useBundleNameStore,
   useIsClickedUpdateFilledButton,
   useIsOpenDetailGiftBoxStore,
   useSelectedBagStore,
@@ -66,7 +66,7 @@ const Header = () => {
   const isGiftUploadPage = pathname === "/gift-upload";
   const isBundleAddPage = pathname === "/bundle/add";
 
-  const { bundleName } = useBundleStore();
+  const { bundleName } = useBundleNameStore();
 
   const bgColor = isAuthPage ? "bg-pink-50" : "bg-white";
 
@@ -190,7 +190,7 @@ const Header = () => {
   };
 
   const Title = () => {
-    const { setBundleName } = useBundleStore();
+    const { setBundleName } = useBundleNameStore();
     const [isEditing, setIsEditing] = useState(false);
     const [inputValue, setInputValue] = useState(dynamicTitle);
 

--- a/src/queries/useCreateBundleMutation.ts
+++ b/src/queries/useCreateBundleMutation.ts
@@ -3,13 +3,16 @@
 import { useMutation } from "@tanstack/react-query";
 
 import { createBundle } from "@/api/bundle/api";
-import { useBundleStore, useSelectedBagStore } from "@/stores/bundle/useStore";
+import {
+  useBundleNameStore,
+  useSelectedBagStore,
+} from "@/stores/bundle/useStore";
 import { useGiftStore } from "@/stores/gift-upload/useStore";
 import { updateGiftBoxesFromResponse } from "@/utils/giftBoxUtils";
 
 export const useCreateBundleMutation = () => {
   const { giftBoxes } = useGiftStore();
-  const { bundleName } = useBundleStore();
+  const { bundleName } = useBundleNameStore();
   const { selectedBagIndex } = useSelectedBagStore();
 
   return useMutation({

--- a/src/stores/bundle/useStore.ts
+++ b/src/stores/bundle/useStore.ts
@@ -21,7 +21,7 @@ interface BundleState {
   setBundleName: (name: string) => void;
 }
 
-export const useBundleStore = create<BundleState>()(
+export const useBundleNameStore = create<BundleState>()(
   persist(
     (set) => ({
       bundleName: "",


### PR DESCRIPTION
### ⚾️ Related Issues

- close #199

### 📝 Task Details

- 기존 보따리 생성할 때 쓰이던 `useBundleStore`를 통해 상세 페이지 접근 시 불러온 name을 전역 상태에 저장하여 상세 페이지 헤더에 보따리 이름을 표시합니다.

### 📂 References

- screenshots, GIFs, etc.

### 💕 Review Requirements

- Please fill out your review request.
