### PR TITLE
style: 답변 대기 중인 보따리의 상세 페이지 내 공유 섹션 위치 하단 고정 및 자잘한 warning 해결

### DIFF
--- a/src/app/my-bundles/[bundleId]/page.tsx
+++ b/src/app/my-bundles/[bundleId]/page.tsx
@@ -186,12 +186,14 @@ const Page = () => {
             <MyCardList data={gifts} type="gift" size="small" />
           </div>
         </div>
-        {/** 답변 대기 중인 상태 */}
+
+        {/** 답변 대기 중인 상태만 링크 공유 가능 */}
         {status === "PUBLISHED" && (
-          <div className="mt-[25px] w-full">
+          <div className="absolute bottom-6 w-full px-4">
             <ShareSection link={link} />
           </div>
         )}
+
         {/* 하단 버튼 (임시 저장, 답변 완료) */}
         <div className="absolute bottom-4 w-full px-4">
           {status === "DRAFT" ? (

--- a/src/app/my-bundles/[bundleId]/page.tsx
+++ b/src/app/my-bundles/[bundleId]/page.tsx
@@ -81,6 +81,8 @@ const Page = () => {
   const memoizedImage = useMemo(() => {
     const imageSrc = DESIGN_TYPE_MAP[designType];
 
+    if (!imageSrc) return null;
+
     return (
       <Image
         src={imageSrc}

--- a/src/app/my-bundles/page.tsx
+++ b/src/app/my-bundles/page.tsx
@@ -110,20 +110,18 @@ const Page = () => {
                   }}
                 />
               ) : (
-                <>
-                  {bundle.id && (
-                    <Link key={bundle.id} href={`/my-bundles/${bundle.id}`}>
-                      <MyBundleCard
-                        isEdit={isEdit}
-                        design_type={bundle.designType}
-                        is_read={bundle.isRead}
-                        status={bundle.status}
-                        name={bundle.name}
-                        updatedAt={bundle.updatedAt}
-                      />
-                    </Link>
-                  )}
-                </>
+                bundle.id && (
+                  <Link key={bundle.id} href={`/my-bundles/${bundle.id}`}>
+                    <MyBundleCard
+                      isEdit={isEdit}
+                      design_type={bundle.designType}
+                      is_read={bundle.isRead}
+                      status={bundle.status}
+                      name={bundle.name}
+                      updatedAt={bundle.updatedAt}
+                    />
+                  </Link>
+                )
               ),
             )}
           </section>

--- a/src/hooks/useDynamicTitle.ts
+++ b/src/hooks/useDynamicTitle.ts
@@ -23,6 +23,7 @@ const useDynamicTitle = () => {
       setDynamicTitle(bundleName);
     } else {
       const pageTitles: { [path: string]: string } = {
+        "/my-bundles": "내가 만든 보따리",
         "/bundle/delivery": "선물 보따리 배달하기",
         "/bundle": "선물 보따리 만들기",
         "/gift-upload": "선물 박스 채우기",


### PR DESCRIPTION
### ⚾️ Related Issues

- close #185 

### 📝 Task Details

- 답변 대기 중인 보따리의 상세 페이지 내 공유 섹션 (카카오톡, 링크) absolute를 통해 하단 고정하였습니다. [b7d4fa3](https://github.com/dnd-side-project/dnd-12th-5-frontend/pull/203/commits/b7d4fa3f3236178914d8f7a0e7b5344f43362bf2)
- `<></>` fragment가 key를 가지고 있지 않아서 생기는 warning을 해결하였습니다. f87dbe36f8cfbae04038b776db756271d06d2e74
- src 속성 undefined 방지하여 warning 해결하였습니다. a8eaa3c56197af5903a59d9130381a422e19670d
- `useDynamicTitle.tsx`에서 '내가 만든 보따리' 타이틀이 빠져있어 추가하였습니다. ed1b91975684d6de994db045e0a57a96228db74c

### 📂 References

- screenshots, GIFs, etc.

### 💕 Review Requirements

- Please fill out your review request.
