### PR TITLE
feat: 보따리 이름 최대 길이 값 수정

### DIFF
--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -1,7 +1,7 @@
 import { IconSize } from "@/types/components/types";
 import { CharacterInfo, CharacterKey } from "@/types/constants/types";
 
-export const BUNDLE_NAME_MAX_LENGTH = 20;
+export const BUNDLE_NAME_MAX_LENGTH = 15;
 export const GIFT_NAME_MAX_LENGTH = 20;
 export const GIFT_IMAGE_MAX_AMOUNT = 5;
 
@@ -160,7 +160,8 @@ export const ICON_SIZE_MAP: Record<IconSize, number> = {
   xsmall: 12,
   small: 14,
   medium: 18,
-  large: 24,
+  large: 20,
+  extraLarge: 24,
 };
 
 export const IMAGE_EXTENSIONS = ["jpg", "jpeg", "png", "webp", "heic", "heif"];


### PR DESCRIPTION
### ⚾️ Related Issues

- close #204

### 📝 Task Details

- 내가 만든 보따리 목록 페이지에서와 헤더 이름 표시 등의 이유로 피그마에서 디자이너 분들과 논의하여 보따리 이름 최대 길이를 20자에서 15자로 수정하였습니다.

### 📂 References

- screenshots, GIFs, etc.

### 💕 Review Requirements

- Please fill out your review request.
