### PR TITLE
feat: 보따리 이름 최대 길이 값 수정

### DIFF
--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -1,7 +1,7 @@
 import { IconSize } from "@/types/components/types";
 import { CharacterInfo, CharacterKey } from "@/types/constants/types";
 
-export const BUNDLE_NAME_MAX_LENGTH = 20;
+export const BUNDLE_NAME_MAX_LENGTH = 15;
 export const GIFT_NAME_MAX_LENGTH = 20;
 export const GIFT_IMAGE_MAX_AMOUNT = 5;
 


### PR DESCRIPTION
### ⚾️ Related Issues

- close #204 

### 📝 Task Details

- 내가 만든 보따리 목록 페이지와 헤더 표시 등의 이유로 보따리 네임 최대 길이가 너무 긴 것 같아서 20자에서 15자로 줄였습니다. 

### 📂 References

- screenshots, GIFs, etc.

### 💕 Review Requirements

- Please fill out your review request.
