### PR TITLE
style: 선물 비우기 drawer 간격 및 아이콘 사이즈 수정

### DIFF
--- a/src/components/bundle/add/DeleteBundleDrawer.tsx
+++ b/src/components/bundle/add/DeleteBundleDrawer.tsx
@@ -21,7 +21,7 @@ const DeleteBundleDrawer = ({
     <DrawerContent>
       <DrawerHeader>
         <>
-          <DrawerTitle className="relative mt-3 text-center text-base font-medium">
+          <DrawerTitle className="relative text-center text-base font-medium">
             <p className="text-center text-base font-medium">
               채워진 선물 정보
             </p>
@@ -31,12 +31,12 @@ const DeleteBundleDrawer = ({
           </DrawerTitle>
         </>
       </DrawerHeader>
-      <div className="flex flex-col items-center justify-center gap-[22px] px-[18px] pb-5">
+      <div className="flex flex-col items-center justify-center px-[18px] pb-5">
         <div className="my-[26px] flex flex-col items-center gap-[7px]">
           <Card img={box?.imgUrls[0] as string} size="small" type="gift" />
           <p>{box?.name}</p>
         </div>
-        <div className="mb-5 flex flex-col gap-1 text-center">
+        <div className="mb-5 flex flex-col text-center">
           <p className="text-[15px]">선택한 박스를 정말 삭제할까요?</p>
           <p className="text-sm text-gray-500">
             삭제된 박스는 되돌릴 수 없어요.

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -160,7 +160,8 @@ export const ICON_SIZE_MAP: Record<IconSize, number> = {
   xsmall: 12,
   small: 14,
   medium: 18,
-  large: 24,
+  large: 20,
+  extraLarge: 24,
 };
 
 export const IMAGE_EXTENSIONS = ["jpg", "jpeg", "png", "webp", "heic", "heif"];

--- a/src/types/components/types.ts
+++ b/src/types/components/types.ts
@@ -41,7 +41,7 @@ export interface DeliveryCardProps {
   characterTitle: string;
 }
 
-export type IconSize = "xsmall" | "small" | "medium" | "large";
+export type IconSize = "xsmall" | "small" | "medium" | "large" | "extraLarge";
 
 export interface IconProps {
   src: string;


### PR DESCRIPTION
### ⚾️ Related Issues

- close #[issue_number]

### 📝 Task Details

- 테스트 중 선물 비우기 drawer 간격이 넓은 것 같아 피그마 참고하여 간격 수정하고, Drawer Close Icon 사이즈도 수정했습니다!

### 📂 References

- screenshots, GIFs, etc.

### 💕 Review Requirements

- Please fill out your review request.
