### PR TITLE
style: 헤더에 title 풀네임 다 표시되도록 수정, 보따리 목록 카드에서는 말줄임 추가

### DIFF
--- a/src/components/myBundle/MyBundleCard.tsx
+++ b/src/components/myBundle/MyBundleCard.tsx
@@ -67,7 +67,9 @@ const MyBundleCard = ({
       )}
       {memoizedImage}
       <div>
-        <p className="text-center text-[15px] font-medium">{name}</p>
+        <p className="max-w-[149px] truncate text-center text-[15px] font-medium">
+          {name}
+        </p>
         <p className="text-center text-xs font-medium text-gray-400">
           {new Date(updatedAt).toISOString().split("T")[0]}
         </p>

--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -233,7 +233,7 @@ const Header = () => {
     };
 
     return isBundleAddPage ? (
-      <div className="flex items-center justify-center">
+      <div className="flex max-w-[200px] items-center justify-center">
         {isEditing ? (
           <Input
             autoFocus

--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -233,7 +233,7 @@ const Header = () => {
     };
 
     return isBundleAddPage ? (
-      <div className="flex max-w-[200px] items-center justify-center">
+      <div className="flex items-center justify-center">
         {isEditing ? (
           <Input
             autoFocus
@@ -260,7 +260,7 @@ const Header = () => {
         )}
       </div>
     ) : (
-      <h1 className="max-w-[220px] overflow-hidden text-ellipsis whitespace-nowrap text-center text-lg font-medium">
+      <h1 className="overflow-hidden text-ellipsis whitespace-nowrap text-center text-lg font-medium">
         {dynamicTitle}
       </h1>
     );


### PR DESCRIPTION
### ⚾️ Related Issues

- close #[issue_number]

### 📝 Task Details

- 내가만든보따리 목록 카드에서 보따리 이름 길이가 최대일 경우(15자) truncate로 처리하였습니다. 
- 상세 페이지에서는 보따리(최대15자)/선물(최대20자) 이름 전체가 표시되어야 할 것 같아서 max-w 속성을 삭제했습니다.

### 📂 References

width 375px 기준입니다.

<img src="https://github.com/user-attachments/assets/e86d874c-48cc-4e69-bd9b-091c6d180d74" width="200" />
<img src="https://github.com/user-attachments/assets/09baa6a4-4488-47e9-afef-066c40968b53" width="200" />
<img src="https://github.com/user-attachments/assets/dff829a6-fe73-4133-a9d6-ed1d46109ba7" width="200" />
<img src="https://github.com/user-attachments/assets/dee37559-2dd2-4317-89ae-f7d59d9ac172" width="200" />



### 💕 Review Requirements

- 테스트하면서 발견했는데, 상세 페이지 -> 마저 채우기 버튼 클릭 -> 선물 이름 수정하고, 뒤로가기 시에 이미 임시저장되어있는 보따리니까 생성할때와 동일하게 홈으로 바로 이동하거나 마저 채우기 버튼을 누른 그 상세 페이지로 이동해야 하는데 수정하는 페이지가 뜨더라고요! 
- 선물 박스 채우기에서는 굳이 전체를 안보여줘도 될 것 같기도 하고.. 수정 아이콘때메 좁아보이긴 하네요! 어떻게 생각하시나요?
