### PR TITLE
style: 전반적인 스타일 수정

### DIFF
--- a/src/app/bundle/add/page.tsx
+++ b/src/app/bundle/add/page.tsx
@@ -67,31 +67,29 @@ const Page = () => {
   };
 
   return (
-    <div className="h-full bg-pink-50 px-4">
-      <div className="relative flex h-full flex-col items-center justify-center">
-        <div className="flex w-[300px] flex-col items-center gap-7">
-          <div className="absolute top-[10px]">
-            <Chip
-              text={`채워진 선물박스 ${filledGiftCount}개`}
-              icon={filledGiftCount > 0 ? <Icon src={RightArrowIcon} /> : ""}
-              width="126px"
-              onClick={() => {
-                if (filledGiftCount > 0) setDrawerOpen(true);
-              }}
-              isClickable={filledGiftCount > 0}
-            />
-          </div>
-          <GiftList value={giftBoxes} />
+    <div className="relative flex h-full flex-col items-center justify-center bg-pink-50">
+      <div className="mb-[68px] flex w-[300px] flex-col items-center gap-7">
+        <div className="absolute top-[10px]">
+          <Chip
+            text={`채워진 선물박스 ${filledGiftCount}개`}
+            icon={filledGiftCount > 0 ? <Icon src={RightArrowIcon} /> : ""}
+            width="126px"
+            onClick={() => {
+              if (filledGiftCount > 0) setDrawerOpen(true);
+            }}
+            isClickable={filledGiftCount > 0}
+          />
         </div>
-        <div className="absolute bottom-4 w-full px-4">
-          <Button
-            disabled={filledGiftCount < MIN_GIFTBOX_AMOUNT}
-            size="lg"
-            onClick={handleClickButton}
-          >
-            선물 배달하러 가기
-          </Button>
-        </div>
+        <GiftList value={giftBoxes} />
+      </div>
+      <div className="absolute bottom-4 w-full px-4">
+        <Button
+          disabled={filledGiftCount < MIN_GIFTBOX_AMOUNT}
+          size="lg"
+          onClick={handleClickButton}
+        >
+          선물 배달하러 가기
+        </Button>
       </div>
       <GiftListDrawer open={drawerOpen} onClose={() => setDrawerOpen(false)} />
     </div>

--- a/src/app/bundle/delivery/step2.tsx
+++ b/src/app/bundle/delivery/step2.tsx
@@ -65,7 +65,7 @@ const Step2 = () => {
   return (
     <div className="h-full bg-[url('/img/background_union.svg')] bg-cover bg-center">
       {characterData && (
-        <div className="flex h-[calc(100%-52px)] w-full flex-col items-center justify-center gap-7">
+        <div className="flex h-[calc(100%-68px)] w-full flex-col items-center justify-center gap-7">
           <section className="flex flex-col items-center">
             <div className="flex flex-col items-center">
               <div className="mb-[3px]">

--- a/src/app/bundle/step1.tsx
+++ b/src/app/bundle/step1.tsx
@@ -7,15 +7,15 @@ import { BUNDLE_IMAGE_PATHS } from "@/constants/constants";
 
 const Step1 = () => {
   return (
-    <div className="flex h-[calc(100%-52px)] flex-col items-center justify-center gap-[46px] px-4">
-      <div className="flex flex-col items-center gap-[34px]">
+    <div className="flex h-[calc(100%-68px)] flex-col items-center justify-center gap-[39px] px-4">
+      <div className="flex flex-col items-center gap-[42px]">
         <SelectedBundle />
         <p className="font-nanum text-base font-bold">
           보따리의 색상을 골라주세요
         </p>
       </div>
       <div
-        className="w-full overflow-x-auto px-4"
+        className="w-full overflow-x-auto"
         style={{ scrollbarWidth: "none" }}
       >
         <div className="min-w-max">

--- a/src/app/bundle/step2.tsx
+++ b/src/app/bundle/step2.tsx
@@ -3,8 +3,8 @@ import SelectedBundle from "@/components/bundle/SelectedBundle";
 
 const Step2 = () => {
   return (
-    <div className="flex h-[calc(100%-52px)] flex-col items-center justify-center gap-[40px] px-4">
-      <div className="flex flex-col items-center gap-[34px]">
+    <div className="flex h-[calc(100%-68px)] flex-col items-center justify-center gap-[39px] px-4">
+      <div className="flex flex-col items-center gap-[42px]">
         <SelectedBundle />
         <p className="font-nanum text-base font-bold">
           선물 보따리의 이름을 적어주세요

--- a/src/app/my-bundles/[bundleId]/[giftId]/page.tsx
+++ b/src/app/my-bundles/[bundleId]/[giftId]/page.tsx
@@ -84,7 +84,7 @@ const Page = () => {
   const filteredMessage = !hasMessage ? "입력된 내용이 없어요" : message;
 
   return (
-    <div className="h-full">
+    <div className="flex h-full flex-col gap-7">
       <Carousel
         setApi={setInnerCarouselApi}
         className="h-[375px] w-full overflow-hidden"
@@ -103,7 +103,7 @@ const Page = () => {
           ))}
         </CarouselContent>
 
-        <div className="absolute bottom-[12px] right-[12px] h-[23px] rounded-[40px] bg-white/70 px-[10px] py-1 text-center">
+        <div className="absolute bottom-3 right-3 h-[23px] rounded-[40px] bg-white/70 px-[10px] py-1 text-center">
           <p className="text-[10px] tracking-[2px] text-gray-600">
             {currentImageIndexes[parseInt(giftId)] !== undefined
               ? currentImageIndexes[parseInt(giftId)] + 1
@@ -113,7 +113,7 @@ const Page = () => {
         </div>
       </Carousel>
 
-      <div className="my-[18px] flex flex-col gap-4 px-4">
+      <div className="flex flex-col gap-4 px-4">
         <div className="flex flex-col gap-[2px]">
           <p className="text-xs text-gray-600">선물을 고른 이유</p>
           <p className={`text-[15px] ${!hasMessage ? "text-gray-300" : ""}`}>

--- a/src/app/my-bundles/[bundleId]/page.tsx
+++ b/src/app/my-bundles/[bundleId]/page.tsx
@@ -81,6 +81,8 @@ const Page = () => {
   const memoizedImage = useMemo(() => {
     const imageSrc = DESIGN_TYPE_MAP[designType];
 
+    if (!imageSrc) return null;
+
     return (
       <Image
         src={imageSrc}
@@ -186,12 +188,14 @@ const Page = () => {
             <MyCardList data={gifts} type="gift" size="small" />
           </div>
         </div>
-        {/** 답변 대기 중인 상태 */}
+
+        {/** 답변 대기 중인 상태만 링크 공유 가능 */}
         {status === "PUBLISHED" && (
-          <div className="mt-[25px] w-full">
+          <div className="absolute bottom-6 w-full px-4">
             <ShareSection link={link} />
           </div>
         )}
+
         {/* 하단 버튼 (임시 저장, 답변 완료) */}
         <div className="absolute bottom-4 w-full px-4">
           {status === "DRAFT" ? (

--- a/src/app/my-bundles/[bundleId]/page.tsx
+++ b/src/app/my-bundles/[bundleId]/page.tsx
@@ -174,8 +174,8 @@ const Page = () => {
 
   return (
     <Drawer open={isDrawerOpen} onOpenChange={setIsDrawerOpen}>
-      <div className="flex h-[calc(100%-52px)] flex-col items-center justify-center px-4">
-        <div className="mb-[40px] mt-[26px] flex flex-col items-center justify-center gap-[20px]">
+      <div className="flex h-[calc(100%-52px)] flex-col items-center justify-center gap-10 px-4">
+        <div className="flex flex-col items-center justify-center gap-5">
           {bundleId && memoizedImage}
           <MyBundleStatusChip status={status} type="message" size="md" />
         </div>
@@ -208,9 +208,9 @@ const Page = () => {
 
               {isDrawerOpen && (
                 <DrawerContent>
-                  <DrawerHeader className="relative mt-3 flex justify-center py-3">
+                  <DrawerHeader className="relative flex justify-center py-3">
                     <DrawerTitle>보따리 삭제</DrawerTitle>
-                    <DrawerClose className="absolute right-[14px] top-2">
+                    <DrawerClose className="absolute right-4 top-[14px]">
                       <Icon src={CloseIcon} alt="close" size="large" />
                     </DrawerClose>
                   </DrawerHeader>

--- a/src/app/my-bundles/[bundleId]/page.tsx
+++ b/src/app/my-bundles/[bundleId]/page.tsx
@@ -175,7 +175,7 @@ const Page = () => {
   return (
     <Drawer open={isDrawerOpen} onOpenChange={setIsDrawerOpen}>
       <div className="flex h-[calc(100%-52px)] flex-col items-center justify-center gap-10 px-4">
-        <div className="flex flex-col items-center justify-center gap-5">
+        <div className="flex flex-col items-center justify-center gap-6">
           {bundleId && memoizedImage}
           <MyBundleStatusChip status={status} type="message" size="md" />
         </div>

--- a/src/app/my-bundles/page.tsx
+++ b/src/app/my-bundles/page.tsx
@@ -110,20 +110,18 @@ const Page = () => {
                   }}
                 />
               ) : (
-                <>
-                  {bundle.id && (
-                    <Link key={bundle.id} href={`/my-bundles/${bundle.id}`}>
-                      <MyBundleCard
-                        isEdit={isEdit}
-                        design_type={bundle.designType}
-                        is_read={bundle.isRead}
-                        status={bundle.status}
-                        name={bundle.name}
-                        updatedAt={bundle.updatedAt}
-                      />
-                    </Link>
-                  )}
-                </>
+                bundle.id && (
+                  <Link key={bundle.id} href={`/my-bundles/${bundle.id}`}>
+                    <MyBundleCard
+                      isEdit={isEdit}
+                      design_type={bundle.designType}
+                      is_read={bundle.isRead}
+                      status={bundle.status}
+                      name={bundle.name}
+                      updatedAt={bundle.updatedAt}
+                    />
+                  </Link>
+                )
               ),
             )}
           </section>

--- a/src/app/my-bundles/page.tsx
+++ b/src/app/my-bundles/page.tsx
@@ -140,7 +140,7 @@ const Page = () => {
               <div className="mb-5 mt-[26px] flex w-full flex-col items-center justify-center gap-[22px]">
                 <div>
                   <p className="text-[15px] font-medium">
-                    선물 보따리를 정말 삭제할까요?
+                    선택한 선물 보따리를 정말 삭제할까요?
                   </p>
                   <p className="text-sm text-gray-300">
                     삭제된 보따리는 되돌릴 수 없어요.

--- a/src/app/my-bundles/page.tsx
+++ b/src/app/my-bundles/page.tsx
@@ -172,7 +172,7 @@ const Page = () => {
             <div className="flex flex-col items-center justify-center gap-4">
               <p>아직 만들어진 보따리가 없어요</p>
               <Link href={"/bundle/select"}>
-                <Button className="w-[130px] rounded-[500px] px-[21px] py-[11px] text-[12px] font-medium">
+                <Button className="w-[130px] rounded-[500px] px-[21px] py-[11px] text-xs font-medium">
                   보따리 만들러 가기
                 </Button>
               </Link>

--- a/src/app/setting/account/page.tsx
+++ b/src/app/setting/account/page.tsx
@@ -9,9 +9,7 @@ const page = () => {
         <Icon src={KakaoLogoIcon} alt="kakao" />
         <p className="text-[15px] font-medium">카카오</p>
       </div>
-      <p className="mt-[24px] px-4 text-[15px] text-symantic-negative">
-        회원 탈퇴
-      </p>
+      <p className="mt-6 px-4 text-[15px] text-symantic-negative">회원 탈퇴</p>
     </div>
   );
 };

--- a/src/components/common/DeliveryCard.tsx
+++ b/src/components/common/DeliveryCard.tsx
@@ -10,7 +10,7 @@ const DeliveryCard = ({
   return (
     <div
       onClick={onClick}
-      className="box-border flex h-[212px] w-[162px] cursor-pointer flex-col items-center justify-center gap-[12px] rounded-[17px] border-[1.4px] border-gray-100 bg-gray-50 px-[14px] pb-[10px] pt-[28px] hover:opacity-70"
+      className="box-border flex h-[212px] w-[162px] cursor-pointer flex-col items-center justify-center gap-3 rounded-[17px] border-[1.4px] border-gray-100 bg-gray-50 px-[14px] pb-[10px] pt-7 hover:opacity-70"
     >
       <Image src={imageSrc} alt="delivery" width={120} height={120} />
       <div className="text-center text-gray-800">

--- a/src/components/common/ShareSection.tsx
+++ b/src/components/common/ShareSection.tsx
@@ -67,7 +67,7 @@ const ShareSection = ({ link }: { link: string }) => {
       </div>
 
       {/* Button Section */}
-      <section className="flex gap-[17px]">
+      <section className="flex gap-3">
         <button
           className="flex flex-col items-center gap-1"
           onClick={shareKakao}

--- a/src/components/myBundle/CopyLinkButton.tsx
+++ b/src/components/myBundle/CopyLinkButton.tsx
@@ -8,7 +8,7 @@ const CopyLinkButton = ({ onClick }: { onClick: () => void }) => {
       onClick={onClick}
       className="flex cursor-pointer items-center gap-[5px] rounded-[4px] bg-gray-100 px-[10px] py-[6px] hover:opacity-70"
     >
-      <p className="text-[12px] font-medium">링크 복사하기</p>
+      <p className="text-xs font-medium">링크 복사하기</p>
       <Icon src={CopyLinkIcon} alt="copy" size="medium" />
     </span>
   );

--- a/src/components/myBundle/MyBundleCard.tsx
+++ b/src/components/myBundle/MyBundleCard.tsx
@@ -43,7 +43,7 @@ const MyBundleCard = ({
 
   return (
     <div
-      className={`relative box-border flex cursor-pointer flex-col items-center justify-center rounded-[12px] border-[1px] border-gray-200 bg-white px-2 pb-[22px] pt-[8px] ${
+      className={`relative box-border flex min-w-[165px] max-w-[192px] cursor-pointer flex-col items-center justify-center rounded-[12px] border-[1px] border-gray-200 bg-white px-2 pb-[22px] pt-[8px] ${
         !isEdit && "hover:bg-gray-100"
       }`}
     >
@@ -66,8 +66,11 @@ const MyBundleCard = ({
         </DrawerTrigger>
       )}
       {memoizedImage}
-      <div>
-        <p className="max-w-[149px] truncate text-center text-[15px] font-medium">
+      <div className="w-full">
+        <p
+          className="mx-auto truncate text-center text-[15px] font-medium"
+          style={{ maxWidth: "calc(100% - 20px)" }}
+        >
           {name}
         </p>
         <p className="text-center text-xs font-medium text-gray-400">

--- a/src/components/myBundle/MyBundleCard.tsx
+++ b/src/components/myBundle/MyBundleCard.tsx
@@ -35,7 +35,7 @@ const MyBundleCard = ({
         alt="Bundle"
         width={89}
         height={94}
-        className="mb-[14px] mt-[8px]"
+        className="mb-[14px] mt-2"
       />
     ),
     [imageSrc],

--- a/src/components/myBundle/MyBundleStatusChip.tsx
+++ b/src/components/myBundle/MyBundleStatusChip.tsx
@@ -33,10 +33,9 @@ const MyBundleStatusChip = ({
     if (type === "message") text = "임시 저장 중";
   }
 
-  const paddingClass =
-    size === "sm" ? "px-[8px] py-[3px]" : "px-[10px] py-[6px]";
+  const paddingClass = size === "sm" ? "px-2 py-[3px]" : "px-[10px] py-[6px]";
 
-  const textSizeClass = size === "sm" ? "text-[10px]" : "text-[12px]";
+  const textSizeClass = size === "sm" ? "text-[10px]" : "text-xs";
 
   return (
     <span

--- a/src/components/myBundle/MyCardList.tsx
+++ b/src/components/myBundle/MyCardList.tsx
@@ -43,7 +43,9 @@ const MyCardList = ({ type, data, size, isSelectable }: MyCardListProps) => {
   };
 
   return (
-    <div className="flex gap-[13px] whitespace-nowrap">
+    <div
+      className={`flex ${size === "small" ? "gap-[13px]" : "gap-[10px]"} whitespace-nowrap`}
+    >
       {data &&
         data.map((item, index) => {
           const bundleDesignURL =
@@ -76,10 +78,8 @@ const MyCardList = ({ type, data, size, isSelectable }: MyCardListProps) => {
                 }
               />
               {isMyBundlePreview(item) && (
-                <div className="ml-[1px]">
-                  <p className="max-w-[86px] truncate text-[12px]">
-                    {item?.name}
-                  </p>
+                <div className="mx-[1px]">
+                  <p className="max-w-[86px] truncate text-xs">{item?.name}</p>
                   <p className="text-[10px] text-gray-300">
                     {formatDateLabel(item?.updatedAt)}
                   </p>

--- a/src/hooks/useDynamicTitle.ts
+++ b/src/hooks/useDynamicTitle.ts
@@ -23,6 +23,7 @@ const useDynamicTitle = () => {
       setDynamicTitle(bundleName);
     } else {
       const pageTitles: { [path: string]: string } = {
+        "/my-bundles": "내가 만든 보따리",
         "/bundle/delivery": "선물 보따리 배달하기",
         "/bundle": "선물 보따리 만들기",
         "/gift-upload": "선물 박스 채우기",

--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -233,7 +233,7 @@ const Header = () => {
     };
 
     return isBundleAddPage ? (
-      <div className="flex max-w-[200px] items-center justify-center">
+      <div className="flex items-center justify-center">
         {isEditing ? (
           <Input
             autoFocus


### PR DESCRIPTION
### ⚾️ Related Issues

- close #210 
- close #211 
- close #212 

### 📝 Task Details

- 보따리 삭제 drawer UI 수정
- 선물 상세 페이지 UI 수정
- 보따리 상세 페이지 스타일 단위 수정
- MyCardList 컴포넌트 size props에 따른 gap size 수정
- 임의 값 대신 Tailwind scale로 정규화
- 내가 만든 보따리 목록 페이지 - 카드 내 보따리 이름 영역 제한하여 특정 영역을 벗어날 시 truncate로 표시되도록 했습니다. [c39451f](https://github.com/dnd-side-project/dnd-12th-5-frontend/pull/209/commits/c39451f9893f03891e0e2952ad5fcd36bc0fb9c3)
- 회의에서 얘기 나누었던 내가 만든 보따리 목록 페이지에서 보따리를 삭제할 경우, 보따리 삭제 drawer에 "선택한" 텍스트를 추가했습니다. [bd3697d](https://github.com/dnd-side-project/dnd-12th-5-frontend/pull/209/commits/bd3697dd08b1bb6f1038359f20bbf67743aef52d)
- 보따리 채우기 페이지에서 헤더에 이름이 잘리지 않고 풀네임이 표시되도록 다시 수정했습니다.
- 보따리 생성 쪽 step1, step2 피그마에 맞춰 스타일 수정했습니다.
- 보따리 채우는 페이지 불필요한 div 제거하여 레이아웃 수정했습니다.
- 배달 페이지 step2의 height를 하단 버튼 제외하도록 수정하였습니다. 

### 📂 References

- screenshots, GIFs, etc.

### 💕 Review Requirements

- Please fill out your review request.
