### PR TITLE
[Style] 답변 선택 페이지 헤더 text 추가

### DIFF
--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -108,8 +108,14 @@ const Header = () => {
 
   if (isBundleDetailStepTwo && isOpenDetailGiftBox) {
     return (
-      <div className="sticky top-0 z-20 flex h-[56px] items-center justify-end bg-gray-100 px-4">
-        <button onClick={() => setIsOpenDetailGiftBox(false)}>
+      <div className="relative sticky top-0 z-20 flex h-[56px] items-center justify-center bg-gray-100 px-4">
+        <h1 className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 text-lg font-medium">
+          답변 선택하기
+        </h1>
+        <button
+          className="ml-auto"
+          onClick={() => setIsOpenDetailGiftBox(false)}
+        >
           <Icon src={CloseIcon} alt="close" size="large" />
         </button>
       </div>


### PR DESCRIPTION
### ⚾️ Related Issues

- close #[issue_number]

### 📝 Task Details

- <img width="1470" alt="image" src="https://github.com/user-attachments/assets/407b8494-3ddd-4164-9751-e4c96bad9be8" />

-> 첨부드린 사진대로 답변 선택하기 페이지의 헤더에 `답변 선택하기` 라는 text를 추가했습니다.

### 📂 References

- screenshots, GIFs, etc.

### 💕 Review Requirements

- Please fill out your review request.
