### PR TITLE
feat: 카카오톡 공유하기 버튼 수정

### DIFF
--- a/src/components/common/ShareSection.tsx
+++ b/src/components/common/ShareSection.tsx
@@ -32,7 +32,7 @@ const ShareSection = ({ link }: { link: string }) => {
         objectType: "feed",
         content: {
           title: "Picktory",
-          description: "선물 보따리가 도착했어요. 🎁",
+          description: "선물 보따리가 도착했어요! 🎁",
           imageUrl: "https://i.imgur.com/4dHZTvt.png",
           link: {
             mobileWebUrl: `${process.env.NEXT_PUBLIC_BASE_URL}/bundle/${link}?step=1`,
@@ -41,9 +41,10 @@ const ShareSection = ({ link }: { link: string }) => {
         },
         buttons: [
           {
-            title: "서비스 이용하러 가기",
+            title: "보따리 풀어보기",
             link: {
-              mobileWebUrl: process.env.NEXT_PUBLIC_BASE_URL,
+              mobileWebUrl: `${process.env.NEXT_PUBLIC_BASE_URL}/bundle/${link}?step=1`,
+              webUrl: `${process.env.NEXT_PUBLIC_BASE_URL}/bundle/${link}?step=1`,
             },
           },
         ],


### PR DESCRIPTION
### ⚾️ Related Issues

- close #[issue_number]

### 📝 Task Details

- 이미지가 아닌 버튼을 클릭해도 응답 페이지로 연결될 수 있도록 `서비스 이용하러 가기` 버튼에서 `보따리 풀어보기` 버튼으로 수정하였습니다.

### 📂 References

- screenshots, GIFs, etc.

### 💕 Review Requirements

- Please fill out your review request.
