### PR TITLE
feat: 보따리 결과 페이지의 title 변경

### DIFF
--- a/src/hooks/useDynamicTitle.ts
+++ b/src/hooks/useDynamicTitle.ts
@@ -13,9 +13,12 @@ const useDynamicTitle = () => {
 
   const singleDetailRegex = /^\/my-bundles\/\d+\/?$/;
   const nestedDetailRegex = /^\/my-bundles\/\d+\/\d+$/;
+  const answerDetailRegex = /^\/my-bundles\/\d+\/answer$/;
 
   useEffect(() => {
-    if (bundleName && singleDetailRegex.test(pathname)) {
+    if (answerDetailRegex.test(pathname)) {
+      setDynamicTitle("보따리 결과");
+    } else if (bundleName && singleDetailRegex.test(pathname)) {
       setDynamicTitle(bundleName);
     } else if (giftName && nestedDetailRegex.test(pathname)) {
       setDynamicTitle(giftName);


### PR DESCRIPTION
### ⚾️ Related Issues

- close #[issue_number]

### 📝 Task Details

- 보따리 결과 페이지의 타이틀이 `내가 만든 보따리`로 되어 있어서 `보따리 결과`로 수정했습니다.

### 📂 References

- screenshots, GIFs, etc.

### 💕 Review Requirements

- Please fill out your review request.
