### PR TITLE
feat: 보따리 채우기 페이지 - 툴팁이 사라지지 않도록 구현

### DIFF
--- a/src/components/bundle/ReceiveGiftList.tsx
+++ b/src/components/bundle/ReceiveGiftList.tsx
@@ -14,7 +14,13 @@ const ReceiveGiftList = ({ giftList, onClick }: ReciveGiftListProps) => {
   const { isUploadedAnswer } = useIsUploadAnswerStore();
 
   return (
-    <div className="grid-rows-[repeat(auto-fill, minmax(130px, 1fr))] grid max-h-[390px] grid-cols-2 gap-[3px]">
+    <div
+      className={`${
+        giftList.length === 1
+          ? "flex h-[130px] items-center justify-center"
+          : "grid max-h-[390px] grid-cols-2 grid-rows-[repeat(auto-fill,_minmax(130px,_1fr))] gap-[3px]"
+      }`}
+    >
       {giftList.map((gift, index) => {
         const isMessageEmpty = !gift.message;
         const shape =

--- a/src/components/bundle/add/CustomTooltipArrow.tsx
+++ b/src/components/bundle/add/CustomTooltipArrow.tsx
@@ -1,0 +1,23 @@
+const CustomTooltipArrow = () => {
+  return (
+    <svg
+      className="absolute -top-[10px] left-1/2 -translate-x-1/2"
+      width="14"
+      height="8"
+      viewBox="0 0 14 8"
+      fill="white"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M1 7 L7 1 L13 7"
+        fill="white"
+        stroke="#1f2937"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={0.6}
+      />
+    </svg>
+  );
+};
+
+export default CustomTooltipArrow;

--- a/src/components/bundle/add/GiftList.tsx
+++ b/src/components/bundle/add/GiftList.tsx
@@ -1,6 +1,6 @@
 import Image from "next/image";
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 import { Drawer, DrawerTrigger } from "../../ui/drawer";
 import {
@@ -54,17 +54,6 @@ const GiftList = ({ value }: { value: GiftBox[] }) => {
       title: "선물박스를 성공적으로 비웠어요!",
     });
   };
-
-  const [showTooltip, setShowTooltip] = useState(false);
-
-  useEffect(() => {
-    if (filledGiftCount === 0) {
-      setShowTooltip(true);
-      const timer = setTimeout(() => setShowTooltip(false), 3000);
-      return () => clearTimeout(timer);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   return (
     <>
@@ -134,8 +123,8 @@ const GiftList = ({ value }: { value: GiftBox[] }) => {
                       router.push(`/gift-upload?index=${index}`);
                     }}
                   >
-                    {index === 0 ? (
-                      <Tooltip open={showTooltip}>
+                    {index === 0 && filledGiftCount === 0 ? (
+                      <Tooltip open={true}>
                         <TooltipTrigger asChild>
                           <Image
                             src={GIFTBOX_DEFAULT_IMAGES[index % 2]}

--- a/src/components/bundle/add/GiftList.tsx
+++ b/src/components/bundle/add/GiftList.tsx
@@ -19,6 +19,7 @@ import { useGiftStore } from "@/stores/gift-upload/useStore";
 import { GiftBox } from "@/types/bundle/types";
 
 import BundleDrawer from "./BundleDrawer";
+import CustomTooltipArrow from "./CustomTooltipArrow";
 import DeleteBundleDrawer from "./DeleteBundleDrawer";
 
 const GiftList = ({ value }: { value: GiftBox[] }) => {
@@ -139,6 +140,7 @@ const GiftList = ({ value }: { value: GiftBox[] }) => {
                           align="center"
                           className="-mt-1 border-[1px] border-gray-800 bg-white px-4 py-2 font-nanum text-[13px] font-bold text-black"
                         >
+                          <CustomTooltipArrow />
                           사진으로 간단하게 <br /> 선물박스를 채워볼까요?
                         </TooltipContent>
                       </Tooltip>


### PR DESCRIPTION
### ⚾️ Related Issues

- close #[issue_number]

### 📝 Task Details

- 테스트하다가 이걸 깜빡했다는 걸 깨닫고.. 급하게 구현해두었습니다!
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/45e4cc48-4472-41a0-bc39-e24e057f4fa5" />

- 선물 박스가 하나라도 채워져있으면 툴팁이 보이게 됩니다.

### 📂 References

- screenshots, GIFs, etc.

### 💕 Review Requirements

- Please fill out your review request.
