### PR TITLE
fix: UTC → KST로 보정

### DIFF
--- a/src/utils/dateFormatter.ts
+++ b/src/utils/dateFormatter.ts
@@ -1,5 +1,7 @@
 export const formatDateLabel = (isoDateString: string): string => {
-  const inputDate = new Date(isoDateString);
+  const KST_OFFSET = 9 * 60 * 60 * 1000;
+
+  const inputDate = new Date(new Date(isoDateString).getTime() + KST_OFFSET);
   const today = new Date();
 
   // 오늘 기준으로 시간 차이 계산


### PR DESCRIPTION
### ⚾️ Related Issues

- close #[issue_number]

### 📝 Task Details

- 보따리를 방금 만들었는데도 home에서 어제라고 표시가 되더라구요! `new Date(isoDateString)`로 파싱할 때 UTC 기준으로 해석될 수 있는 ISO 문자열을 그대로 넣으면 시간 차이가 발생할 수 있다고 합니다. 따라서, 한국 시간(KST)을 기준으로 계산하기 위해 UTC 기준 시간에 9시간을 더해 KST 시간으로 변환하였습니다.

### 📂 References

- screenshots, GIFs, etc.

### 💕 Review Requirements

- Please fill out your review request.
