### PR TITLE
fix: 배달 준비 중 로딩 페이지에서 close 버튼 숨기기

### DIFF
--- a/src/app/bundle/delivery/step3.tsx
+++ b/src/app/bundle/delivery/step3.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image";
 import { useSearchParams } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 
 import ShareSection from "@/components/common/ShareSection";
 import { CHARACTERS, BUNDLE_COLORS } from "@/constants/constants";

--- a/src/app/bundle/delivery/step3.tsx
+++ b/src/app/bundle/delivery/step3.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Image from "next/image";
-import { useSearchParams } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 
 import ShareSection from "@/components/common/ShareSection";
@@ -10,12 +10,24 @@ import { useSelectedBagStore } from "@/stores/bundle/useStore";
 
 const Step3 = () => {
   const searchParams = useSearchParams();
+  const pathname = usePathname();
+  const router = useRouter();
+
   const characterKo = searchParams?.get("character") ?? "포리";
   const link = searchParams && searchParams.get("link");
   const [isLoading, setIsLoading] = useState(true);
-
   useEffect(() => {
-    const timer = setTimeout(() => setIsLoading(false), 3000);
+    // 로딩 시작 시 URL에 hideClose=true 추가
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("hideClose", "true");
+    router.replace(`${pathname}?${params.toString()}`);
+
+    const timer = setTimeout(() => {
+      setIsLoading(false);
+      params.delete("hideClose");
+      router.replace(`${pathname}?${params.toString()}`);
+    }, 3000);
+
     return () => clearTimeout(timer);
   }, []);
 

--- a/src/app/bundle/delivery/step3.tsx
+++ b/src/app/bundle/delivery/step3.tsx
@@ -1,31 +1,25 @@
 "use client";
 
 import Image from "next/image";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 
 import ShareSection from "@/components/common/ShareSection";
 import { CHARACTERS, BUNDLE_COLORS } from "@/constants/constants";
-import { useSelectedBagStore } from "@/stores/bundle/useStore";
+import { useLoadingStore, useSelectedBagStore } from "@/stores/bundle/useStore";
 
 const Step3 = () => {
   const searchParams = useSearchParams();
-  const pathname = usePathname();
-  const router = useRouter();
 
   const characterKo = searchParams?.get("character") ?? "포리";
   const link = searchParams && searchParams.get("link");
-  const [isLoading, setIsLoading] = useState(true);
+  const { isLoading, setIsLoading } = useLoadingStore();
+
   useEffect(() => {
-    // 로딩 시작 시 URL에 hideClose=true 추가
-    const params = new URLSearchParams(searchParams.toString());
-    params.set("hideClose", "true");
-    router.replace(`${pathname}?${params.toString()}`);
+    setIsLoading(true);
 
     const timer = setTimeout(() => {
       setIsLoading(false);
-      params.delete("hideClose");
-      router.replace(`${pathname}?${params.toString()}`);
     }, 3000);
 
     return () => clearTimeout(timer);

--- a/src/app/my-bundles/page.tsx
+++ b/src/app/my-bundles/page.tsx
@@ -171,7 +171,7 @@ const Page = () => {
           <div className="flex h-full items-center justify-center">
             <div className="flex flex-col items-center justify-center gap-4">
               <p>아직 만들어진 보따리가 없어요</p>
-              <Link href={"/bundle/select"}>
+              <Link href="/bundle?step=1">
                 <Button className="w-[130px] rounded-[500px] px-[21px] py-[11px] text-xs font-medium">
                   보따리 만들러 가기
                 </Button>

--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -154,7 +154,7 @@ const Header = () => {
   }
 
   const BackButton = () => {
-    if (isStepThree && isBundleDeliveryPage) return null;
+    if (isStepThree && isBundleDeliveryPage && isLoading) return null;
 
     const handleBack = () => {
       if (isGiftUploadPage) setIsBoxEditing(false);

--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -48,17 +48,18 @@ const Header = () => {
   const router = useRouter();
   const searchParams = useSearchParams();
   const step = searchParams?.get("step");
+  const isStepThree = step === "3";
   const isEdit = searchParams.get("isEdit") === "true";
 
   const dynamicTitle = useDynamicTitle(); // 타이틀 동적 업데이트
 
-  const [isStepThree, setIsStepThree] = useState(false);
   const [showGoToHomeDrawer, setShowGoToHomeDrawer] = useState(false);
 
   const { setIsBoxEditing } = useEditBoxStore();
-
   const { isOpenDetailGiftBox, setIsOpenDetailGiftBox } =
     useIsOpenDetailGiftBoxStore();
+  const { bundleName } = useBundleNameStore();
+  const isLoading = useLoadingStore((state) => state.isLoading);
 
   const isAuthPage = ["/auth/login"].includes(pathname ?? "");
   const isHomePage = pathname === "/home";
@@ -69,17 +70,7 @@ const Header = () => {
   const isGiftUploadPage = pathname === "/gift-upload";
   const isBundleAddPage = pathname === "/bundle/add";
 
-  const { bundleName } = useBundleNameStore();
-
   const bgColor = isAuthPage ? "bg-pink-50" : "bg-white";
-
-  useEffect(() => {
-    setIsStepThree(step === "3");
-  }, [searchParams, step]);
-
-  useEffect(() => {
-    setIsStepThree(false);
-  }, [pathname]);
 
   const isBundleDetailStepTwo =
     pathname?.startsWith("/bundle/") && searchParams?.get("step") === "2";
@@ -285,8 +276,6 @@ const Header = () => {
         </Button>
       );
     }
-
-    const isLoading = useLoadingStore((state) => state.isLoading);
 
     if (isBundleDeliveryPage && isStepThree && !isLoading) {
       return (

--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -25,6 +25,7 @@ import {
   useIsClickedUpdateFilledButton,
   useIsOpenDetailGiftBoxStore,
   useSelectedBagStore,
+  useLoadingStore,
 } from "@/stores/bundle/useStore";
 import { useEditBoxStore, useGiftStore } from "@/stores/gift-upload/useStore";
 
@@ -285,9 +286,9 @@ const Header = () => {
       );
     }
 
-    const hideClose = searchParams?.get("hideClose") === "true";
+    const isLoading = useLoadingStore((state) => state.isLoading);
 
-    if (isBundleDeliveryPage && isStepThree && !hideClose) {
+    if (isBundleDeliveryPage && isStepThree && !isLoading) {
       return (
         <Button
           onClick={() => router.push("/home")}

--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -285,7 +285,9 @@ const Header = () => {
       );
     }
 
-    if (isBundleDeliveryPage && isStepThree) {
+    const hideClose = searchParams?.get("hideClose") === "true";
+
+    if (isBundleDeliveryPage && isStepThree && !hideClose) {
       return (
         <Button
           onClick={() => router.push("/home")}

--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -154,7 +154,7 @@ const Header = () => {
   }
 
   const BackButton = () => {
-    if (isStepThree && isBundleDeliveryPage && isLoading) return null;
+    if ((isStepThree && isBundleDeliveryPage) || isLoading) return null;
 
     const handleBack = () => {
       if (isGiftUploadPage) setIsBoxEditing(false);

--- a/src/stores/bundle/useStore.ts
+++ b/src/stores/bundle/useStore.ts
@@ -131,3 +131,13 @@ export const useIsClickedUpdateFilledButton =
       },
     ),
   );
+
+interface LoadingState {
+  isLoading: boolean;
+  setIsLoading: (val: boolean) => void;
+}
+
+export const useLoadingStore = create<LoadingState>((set) => ({
+  isLoading: false,
+  setIsLoading: (val) => set({ isLoading: val }),
+}));


### PR DESCRIPTION
### ⚾️ Related Issues

- close #222

### 📝 Task Details

- ~~params에 `hideClose`를 추가하여 로딩 페이지에서는 close 버튼이 표시되지 않도록 했습니다. 더 좋은 방식이 있을까요?!~~
- 로딩 상태를 전역으로 관리하여 Header에서 검증하는 것이 더 직관적이라고 생각하여 (추후 모든 로딩 상태일때는 뒤로가기나 close버튼 표시되지 않도록) 로딩 상태를 전역으로 관리하는 방식으로 수정하였습니다!
- 로딩 상태라면 back button도 비활성화되도록 했습니다.

### 📂 References

- screenshots, GIFs, etc.

### 💕 Review Requirements

- Please fill out your review request.
