### PR TITLE
style: 보따리 채우기 페이지 레이아웃 수정

### DIFF
--- a/src/app/bundle/add/page.tsx
+++ b/src/app/bundle/add/page.tsx
@@ -68,7 +68,7 @@ const Page = () => {
 
   return (
     <div className="relative flex h-full flex-col items-center justify-center bg-pink-50">
-      <div className="mb-[68px] flex w-[300px] flex-col items-center gap-7">
+      <div className="mb-[26px] flex w-[300px] flex-col items-center gap-7">
         <div className="absolute top-[10px]">
           <Chip
             text={`채워진 선물박스 ${filledGiftCount}개`}


### PR DESCRIPTION
### ⚾️ Related Issues

- close #[issue_number]

### 📝 Task Details

- 상단 채워진 선물박스 chip과 버튼 사이 공간에서 가운데 정렬되도록 수정했습니다. (위 제외할 공간 42px, 아래 68px - 68-42=26px)

### 📂 References

![image](https://github.com/user-attachments/assets/5f056fd6-d21c-421e-bb14-788c9693f264)

### 💕 Review Requirements

- Please fill out your review request.
