### PR TITLE
fix: 보따리 최초 생성 상태를 전역 상태로 관리

### DIFF
--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -12,9 +12,11 @@ import useResetStore from "@/hooks/useResetStore";
 
 import MainGraphic from "/public/img/main_graphic.svg";
 import ArrowRightIcon from "/public/icons/arrow_right_small.svg";
+import { useHandleCreateBundleClick } from "@/hooks/bundle/add/useHandleCreateBundleClick";
 
 const Page = () => {
   useResetStore();
+  const handleBundleCreate = useHandleCreateBundleClick();
 
   const { data, isLoading, isError } = useBundlesPreviewQuery();
   if (!data) return;
@@ -30,12 +32,14 @@ const Page = () => {
           style={{ height: "auto" }}
           priority
         />
-        <Link
-          href="/bundle?step=1"
+
+        <Button
+          size="lg"
+          onClick={handleBundleCreate}
           className="absolute bottom-3 left-1/2 w-[calc(100%-24px)] max-w-[370px] -translate-x-1/2"
         >
-          <Button size="lg">보따리 만들러 가기</Button>
-        </Link>
+          보따리 만들러 가기
+        </Button>
       </div>
       <section className="flex w-full flex-col gap-[14px]">
         <div className="flex items-center justify-between">

--- a/src/app/my-bundles/[bundleId]/page.tsx
+++ b/src/app/my-bundles/[bundleId]/page.tsx
@@ -24,7 +24,8 @@ import { useDraftBundleGiftsQuery } from "@/queries/useDraftBundleGiftsQuery";
 import { useMyBundleDetailQuery } from "@/queries/useMyBundleDetailQuery";
 import {
   useBundleNameStore,
-  useIsClickedUpdateFilledButton,
+  useBundleEditStore,
+  useBundleCreateStore,
 } from "@/stores/bundle/useStore";
 import { useGiftStore } from "@/stores/gift-upload/useStore";
 
@@ -39,6 +40,8 @@ const Page = () => {
 
   const { setBundleName } = useBundleNameStore();
   const { updateGiftBox } = useGiftStore();
+  const { setIsEditing } = useBundleEditStore();
+  const { setIsCreating } = useBundleCreateStore();
 
   const { data } = useMyBundleDetailQuery(parseInt(bundleId));
   const { name, designType, link, status, gifts } = data?.result || {
@@ -55,11 +58,9 @@ const Page = () => {
     }
   }, [name]);
 
-  const { setIsClickedUpdateFilledButton } = useIsClickedUpdateFilledButton();
-
   useEffect(() => {
-    setIsClickedUpdateFilledButton(false);
-  }, [setIsClickedUpdateFilledButton]);
+    setIsEditing(false);
+  }, [setIsEditing]);
 
   const { mutate: deleteBundle } = useDeleteMyBundleMutation();
 
@@ -154,16 +155,18 @@ const Page = () => {
 
       await Promise.all(updatePromises);
 
-      router.push("/bundle/add?isEdit=true");
+      router.push("/bundle/add");
     } catch (error) {
       console.error(error);
     }
   };
 
+  // 마저 채우기 버튼 클릭 시
   const handleFillBundle = async () => {
     resetStore(); // 기존 임시 저장 데이터 초기화
     if (bundleId) sessionStorage.setItem("bundleId", bundleId);
-    setIsClickedUpdateFilledButton(true);
+    setIsEditing(true); // 편집 상태로 전환
+    setIsCreating(false); // 최초 생성 상태 false
 
     try {
       await fetchSavedGift();

--- a/src/app/my-bundles/[bundleId]/page.tsx
+++ b/src/app/my-bundles/[bundleId]/page.tsx
@@ -24,7 +24,6 @@ import { useDraftBundleGiftsQuery } from "@/queries/useDraftBundleGiftsQuery";
 import { useMyBundleDetailQuery } from "@/queries/useMyBundleDetailQuery";
 import {
   useBundleNameStore,
-  useBundleEditStore,
   useBundleCreateStore,
 } from "@/stores/bundle/useStore";
 import { useGiftStore } from "@/stores/gift-upload/useStore";
@@ -40,7 +39,6 @@ const Page = () => {
 
   const { setBundleName } = useBundleNameStore();
   const { updateGiftBox } = useGiftStore();
-  const { setIsEditing } = useBundleEditStore();
   const { setIsCreating } = useBundleCreateStore();
 
   const { data } = useMyBundleDetailQuery(parseInt(bundleId));
@@ -57,10 +55,6 @@ const Page = () => {
       setBundleName(name);
     }
   }, [name]);
-
-  useEffect(() => {
-    setIsEditing(false);
-  }, [setIsEditing]);
 
   const { mutate: deleteBundle } = useDeleteMyBundleMutation();
 
@@ -165,7 +159,6 @@ const Page = () => {
   const handleFillBundle = async () => {
     resetStore(); // 기존 임시 저장 데이터 초기화
     if (bundleId) sessionStorage.setItem("bundleId", bundleId);
-    setIsEditing(true); // 편집 상태로 전환
     setIsCreating(false); // 최초 생성 상태 false
 
     try {

--- a/src/app/my-bundles/[bundleId]/page.tsx
+++ b/src/app/my-bundles/[bundleId]/page.tsx
@@ -24,7 +24,7 @@ import { useDraftBundleGiftsQuery } from "@/queries/useDraftBundleGiftsQuery";
 import { useMyBundleDetailQuery } from "@/queries/useMyBundleDetailQuery";
 import {
   useBundleNameStore,
-  useBundleCreateStore,
+  useCreatingBundleStore,
 } from "@/stores/bundle/useStore";
 import { useGiftStore } from "@/stores/gift-upload/useStore";
 
@@ -39,7 +39,7 @@ const Page = () => {
 
   const { setBundleName } = useBundleNameStore();
   const { updateGiftBox } = useGiftStore();
-  const { setIsCreating } = useBundleCreateStore();
+  const { setIsCreatingBundle } = useCreatingBundleStore();
 
   const { data } = useMyBundleDetailQuery(parseInt(bundleId));
   const { name, designType, link, status, gifts } = data?.result || {
@@ -159,7 +159,7 @@ const Page = () => {
   const handleFillBundle = async () => {
     resetStore(); // 기존 임시 저장 데이터 초기화
     if (bundleId) sessionStorage.setItem("bundleId", bundleId);
-    setIsCreating(false); // 최초 생성 상태 false
+    setIsCreatingBundle(false); // 최초 생성 상태 false
 
     try {
       await fetchSavedGift();

--- a/src/app/my-bundles/page.tsx
+++ b/src/app/my-bundles/page.tsx
@@ -21,6 +21,7 @@ import {
 import { useDeleteMyBundleMutation } from "@/queries/useDeleteMyBundleMutation";
 import { useMyBundlesQuery } from "@/queries/useMyBundlesQuery";
 import { MyBundle } from "@/types/bundle/types";
+import { useHandleCreateBundleClick } from "@/hooks/bundle/add/useHandleCreateBundleClick";
 
 const Page = () => {
   const [isEdit, setIsEdit] = useState(false);
@@ -48,6 +49,8 @@ const Page = () => {
     },
     [deleteBundle],
   );
+
+  const handleBundleCreate = useHandleCreateBundleClick();
 
   if (isLoading) {
     return (
@@ -171,11 +174,13 @@ const Page = () => {
           <div className="flex h-full items-center justify-center">
             <div className="flex flex-col items-center justify-center gap-4">
               <p>아직 만들어진 보따리가 없어요</p>
-              <Link href="/bundle?step=1">
-                <Button className="w-[130px] rounded-[500px] px-[21px] py-[11px] text-xs font-medium">
-                  보따리 만들러 가기
-                </Button>
-              </Link>
+
+              <Button
+                onClick={handleBundleCreate}
+                className="w-[130px] rounded-[500px] px-[21px] py-[11px] text-xs font-medium"
+              >
+                보따리 만들러 가기
+              </Button>
             </div>
           </div>
         </>

--- a/src/hooks/bundle/add/useHandleCreateBundleClick.ts
+++ b/src/hooks/bundle/add/useHandleCreateBundleClick.ts
@@ -1,12 +1,12 @@
 import { useRouter } from "next/navigation";
-import { useBundleCreateStore } from "@/stores/bundle/useStore";
+import { useCreatingBundleStore } from "@/stores/bundle/useStore";
 
 export const useHandleCreateBundleClick = () => {
   const router = useRouter();
-  const { setIsCreating } = useBundleCreateStore();
+  const { setIsCreatingBundle } = useCreatingBundleStore();
 
   return () => {
-    setIsCreating(true); // 최초 생성 상태
+    setIsCreatingBundle(true); // 최초 생성 상태
     router.push("/bundle?step=1");
   };
 };

--- a/src/hooks/bundle/add/useHandleCreateBundleClick.ts
+++ b/src/hooks/bundle/add/useHandleCreateBundleClick.ts
@@ -1,0 +1,12 @@
+import { useRouter } from "next/navigation";
+import { useBundleCreateStore } from "@/stores/bundle/useStore";
+
+export const useHandleCreateBundleClick = () => {
+  const router = useRouter();
+  const { setIsCreating } = useBundleCreateStore();
+
+  return () => {
+    setIsCreating(true); // 최초 생성 상태
+    router.push("/bundle?step=1");
+  };
+};

--- a/src/hooks/useResetStore.ts
+++ b/src/hooks/useResetStore.ts
@@ -3,22 +3,19 @@ import { useEffect } from "react";
 import {
   useSelectedBagStore,
   useBundleNameStore,
-  useBundleEditStore,
 } from "@/stores/bundle/useStore";
 import { resetGiftBoxes } from "@/utils/giftBoxUtils";
 
 const useResetStore = () => {
   const { setSelectedBagIndex } = useSelectedBagStore();
   const { setBundleName } = useBundleNameStore();
-  const { setIsEditing } = useBundleEditStore();
 
   useEffect(() => {
     resetGiftBoxes();
     setSelectedBagIndex(0);
     setBundleName("");
     sessionStorage.removeItem("bundleId");
-    setIsEditing(false);
-  }, [setSelectedBagIndex, setBundleName, setIsEditing]);
+  }, [setSelectedBagIndex, setBundleName]);
 };
 
 export default useResetStore;

--- a/src/hooks/useResetStore.ts
+++ b/src/hooks/useResetStore.ts
@@ -3,22 +3,22 @@ import { useEffect } from "react";
 import {
   useSelectedBagStore,
   useBundleNameStore,
-  useIsClickedUpdateFilledButton,
+  useBundleEditStore,
 } from "@/stores/bundle/useStore";
 import { resetGiftBoxes } from "@/utils/giftBoxUtils";
 
 const useResetStore = () => {
   const { setSelectedBagIndex } = useSelectedBagStore();
   const { setBundleName } = useBundleNameStore();
-  const { setIsClickedUpdateFilledButton } = useIsClickedUpdateFilledButton();
+  const { setIsEditing } = useBundleEditStore();
 
   useEffect(() => {
     resetGiftBoxes();
     setSelectedBagIndex(0);
     setBundleName("");
     sessionStorage.removeItem("bundleId");
-    setIsClickedUpdateFilledButton(false);
-  }, [setSelectedBagIndex, setBundleName, setIsClickedUpdateFilledButton]);
+    setIsEditing(false);
+  }, [setSelectedBagIndex, setBundleName, setIsEditing]);
 };
 
 export default useResetStore;

--- a/src/hooks/useTempSaveBundle.ts
+++ b/src/hooks/useTempSaveBundle.ts
@@ -1,12 +1,10 @@
 import { createBundle, updateBundle } from "@/api/bundle/api";
 import { toast } from "@/hooks/use-toast";
-import { useBundleEditStore } from "@/stores/bundle/useStore";
 import { useGiftStore } from "@/stores/gift-upload/useStore";
 import { updateGiftBoxesFromResponse } from "@/utils/giftBoxUtils";
 
 export const useTempSaveBundle = () => {
   const { giftBoxes } = useGiftStore();
-  const { setIsEditing } = useBundleEditStore();
 
   const handleTempSave = async ({
     bundleName,
@@ -41,7 +39,6 @@ export const useTempSaveBundle = () => {
       toast({
         title: "보따리 임시저장을 완료했어요!",
       });
-      setIsEditing(true); // 임시 저장 후 편집 상태로 전환
       return true;
     } catch (error) {
       console.error(error);

--- a/src/hooks/useTempSaveBundle.ts
+++ b/src/hooks/useTempSaveBundle.ts
@@ -1,10 +1,12 @@
 import { createBundle, updateBundle } from "@/api/bundle/api";
 import { toast } from "@/hooks/use-toast";
+import { useBundleEditStore } from "@/stores/bundle/useStore";
 import { useGiftStore } from "@/stores/gift-upload/useStore";
 import { updateGiftBoxesFromResponse } from "@/utils/giftBoxUtils";
 
 export const useTempSaveBundle = () => {
   const { giftBoxes } = useGiftStore();
+  const { setIsEditing } = useBundleEditStore();
 
   const handleTempSave = async ({
     bundleName,
@@ -39,6 +41,7 @@ export const useTempSaveBundle = () => {
       toast({
         title: "보따리 임시저장을 완료했어요!",
       });
+      setIsEditing(true); // 임시 저장 후 편집 상태로 전환
       return true;
     } catch (error) {
       console.error(error);

--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -21,7 +21,7 @@ import useDynamicTitle from "@/hooks/useDynamicTitle";
 import { useTempSaveBundle } from "@/hooks/useTempSaveBundle";
 import { useEditDraftBundleNameMutation } from "@/queries/useEditDraftBundleNameMutation";
 import {
-  useBundleCreateStore,
+  useCreatingBundleStore,
   useBundleNameStore,
   useIsOpenDetailGiftBoxStore,
   useSelectedBagStore,
@@ -54,7 +54,7 @@ const Header = () => {
   const [showGoToHomeDrawer, setShowGoToHomeDrawer] = useState(false);
 
   const { setIsBoxEditing } = useEditBoxStore();
-  const { isCreating } = useBundleCreateStore();
+  const { isCreatingBundle } = useCreatingBundleStore();
 
   const { isOpenDetailGiftBox, setIsOpenDetailGiftBox } =
     useIsOpenDetailGiftBoxStore();
@@ -169,7 +169,7 @@ const Header = () => {
         // 임시 저장된 보따리의 경우
         if (bundleId) {
           // 최초 생성 상태인 경우
-          if (isCreating) {
+          if (isCreatingBundle) {
             router.push("/home");
           } else {
             router.push(`/my-bundles/${bundleId}`);

--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -172,7 +172,7 @@ const Header = () => {
           if (isCreating) {
             router.push("/home");
           } else {
-            router.back();
+            router.push(`/my-bundles/${bundleId}`);
           }
         } else {
           const hasFilledBox = giftBoxes.some((box) => box?.filled);

--- a/src/stores/bundle/useStore.ts
+++ b/src/stores/bundle/useStore.ts
@@ -113,12 +113,13 @@ export const useIsUploadAnswerStore = create<IsUploadAnswerStore>()(
   ),
 );
 
+/** 보따리 최초 생성 상태를 관리하는 store */
 interface BundleCreateState {
-  isCreating: boolean;
-  setIsCreating: (value: boolean) => void;
+  isCreatingBundle: boolean;
+  setIsCreatingBundle: (value: boolean) => void;
 }
 
-export const useBundleCreateStore = create<BundleCreateState>((set) => ({
-  isCreating: false,
-  setIsCreating: (value) => set({ isCreating: value }),
+export const useCreatingBundleStore = create<BundleCreateState>((set) => ({
+  isCreatingBundle: false,
+  setIsCreatingBundle: (value) => set({ isCreatingBundle: value }),
 }));

--- a/src/stores/bundle/useStore.ts
+++ b/src/stores/bundle/useStore.ts
@@ -113,16 +113,6 @@ export const useIsUploadAnswerStore = create<IsUploadAnswerStore>()(
   ),
 );
 
-interface BundleEditState {
-  isEditing: boolean;
-  setIsEditing: (value: boolean) => void;
-}
-
-export const useBundleEditStore = create<BundleEditState>((set) => ({
-  isEditing: false,
-  setIsEditing: (value) => set({ isEditing: value }),
-}));
-
 interface BundleCreateState {
   isCreating: boolean;
   setIsCreating: (value: boolean) => void;

--- a/src/stores/bundle/useStore.ts
+++ b/src/stores/bundle/useStore.ts
@@ -113,21 +113,22 @@ export const useIsUploadAnswerStore = create<IsUploadAnswerStore>()(
   ),
 );
 
-interface IsClickedUpdateFilledButtonStore {
-  isClickedUpdateFilledButton: boolean;
-  setIsClickedUpdateFilledButton: (isClicked: boolean) => void;
+interface BundleEditState {
+  isEditing: boolean;
+  setIsEditing: (value: boolean) => void;
 }
 
-export const useIsClickedUpdateFilledButton =
-  create<IsClickedUpdateFilledButtonStore>()(
-    persist(
-      (set) => ({
-        isClickedUpdateFilledButton: false,
-        setIsClickedUpdateFilledButton: (isClicked) =>
-          set({ isClickedUpdateFilledButton: isClicked }),
-      }),
-      {
-        name: "cilcked-updateFilledButton",
-      },
-    ),
-  );
+export const useBundleEditStore = create<BundleEditState>((set) => ({
+  isEditing: false,
+  setIsEditing: (value) => set({ isEditing: value }),
+}));
+
+interface BundleCreateState {
+  isCreating: boolean;
+  setIsCreating: (value: boolean) => void;
+}
+
+export const useBundleCreateStore = create<BundleCreateState>((set) => ({
+  isCreating: false,
+  setIsCreating: (value) => set({ isCreating: value }),
+}));


### PR DESCRIPTION
### ⚾️ Related Issues

- close #[issue_number]

### 📝 Task Details

- 기존 `useIsClickedUpdateFilledButton ` 전역 상태를 제거하고, sessiontStorage 로 관리되고 있던 `bundleId`를 통해 임시 저장 상태를 감지하도록 변경했습니다.
- 새로운 전역 상태 `isCreating`를 추가하여 최초 생성 상태와 임시 저장 상태를 구분하고, 뒤로가기 버튼 동작을 수정했습니다. `isCreating`이 true이고 `bundleId`가 존재하는 경우 `/home`으로 이동하고, `isCreating`이 false이며 `bundleId`가 존재하는 경우 상세 페이지(`/my-bundles/{bundleId}`)로 이동합니다.
- `보따리 만들러 가기` 버튼 동작을 처리하기 위해 `useHandleCreateBundleClick.ts` 훅을 새로 작성했습니다. 이 버튼은 홈 화면 또는 내가 만든 보따리가 하나도 없을 때 노출되며, 클릭 시 `isCreating`을 true로 설정하고 `/bundle?step=1`로 이동합니다.
- `마저 채우기` 버튼을 클릭하는 경우에는 `isCreating`을 false로 설정하여, 최초 생성이 아님을 명시합니다.

### 📂 References

- screenshots, GIFs, etc.

### 💕 Review Requirements

- 