### PR TITLE
feat: open graph 구현

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,7 @@
     "plugin:prettier/recommended",
     "plugin:import/typescript"
   ],
-  "plugins": ["prettier", "eslint-plugin-import"],
+  "plugins": ["prettier", "import"],
   "rules": {
     "prettier/prettier": "error",
     "import/order": [
@@ -21,7 +21,9 @@
           "object",
           "type"
         ],
-        "pathGroups": [{ "pattern": "@/**", "group": "parent" }],
+        "pathGroups": [
+          { "pattern": "@/**", "group": "internal", "position": "after" }
+        ],
         "pathGroupsExcludedImportTypes": ["builtin"],
         "alphabetize": {
           "order": "asc", // 알파벳 순서로 정렬

--- a/src/api/bundle/api.ts
+++ b/src/api/bundle/api.ts
@@ -1,5 +1,3 @@
-import { PICKTORY_API } from "../api-url";
-import axiosInstance from "../axiosInstance";
 import { BUNDLE_COLORS } from "@/constants/constants";
 import {
   GiftWithResponseTag,
@@ -9,6 +7,9 @@ import {
   ReceiveBundle,
 } from "@/types/bundle/types";
 import { handleAxiosError } from "@/utils/axios";
+
+import { PICKTORY_API } from "../api-url";
+import axiosInstance from "../axiosInstance";
 
 /** 보따리 생성 api */
 export const createBundle = async ({

--- a/src/api/gift-upload/api.ts
+++ b/src/api/gift-upload/api.ts
@@ -1,6 +1,7 @@
+import { handleAxiosError } from "@/utils/axios";
+
 import { PICKTORY_API } from "../api-url";
 import axiosInstance from "../axiosInstance";
-import { handleAxiosError } from "@/utils/axios";
 
 export const uploadGiftImages = async (
   formData: FormData,

--- a/src/api/kakao/api.ts
+++ b/src/api/kakao/api.ts
@@ -1,6 +1,7 @@
+import { handleAxiosError } from "@/utils/axios";
+
 import { PICKTORY_API } from "../api-url";
 import axiosInstance from "../axiosInstance";
-import { handleAxiosError } from "@/utils/axios";
 
 export const kakaoLogin = async (code: string) => {
   try {

--- a/src/api/my-bundle/api.ts
+++ b/src/api/my-bundle/api.ts
@@ -1,7 +1,8 @@
-import { PICKTORY_API } from "../api-url";
-import axiosInstance from "../axiosInstance";
 import { ResultGiftBox } from "@/types/bundle/types";
 import { handleAxiosError } from "@/utils/axios";
+
+import { PICKTORY_API } from "../api-url";
+import axiosInstance from "../axiosInstance";
 
 /** 메인화면 보따리 조회 api */
 export const getBundlesPreview = async () => {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -38,6 +38,19 @@ export const metadata: Metadata = {
       { rel: "icon", url: "/favicon/favicon-192x192.png", sizes: "192x192" },
     ],
   },
+  openGraph: {
+    title: "Picktory",
+    description: "마음을 전하는 가장 쉬운 방법",
+    url: "https://www.picktory.net",
+    images: [
+      {
+        url: "https://i.imgur.com/ZhadG4p.png",
+        width: 1200,
+        height: 630,
+        alt: "Picktory Thumbnail",
+      },
+    ],
+  },
 };
 
 export default function RootLayout({

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,6 @@
-import type { Metadata } from "next";
-
-import localFont from "next/font/local";
-
 import "./globals.css";
 
+import localFont from "next/font/local";
 import { headers } from "next/headers";
 import { Suspense } from "react";
 
@@ -13,6 +10,8 @@ import { Toaster } from "@/components/ui/toaster";
 import Header from "@/layout/Header";
 
 import { Providers } from "./providers";
+
+import type { Metadata } from "next";
 
 const pretendard = localFont({
   src: "./fonts/PretendardVariable.woff2",

--- a/src/components/bundle/DetailGiftBox.tsx
+++ b/src/components/bundle/DetailGiftBox.tsx
@@ -3,6 +3,9 @@
 import Image from "next/image";
 import { useEffect, useState } from "react";
 
+import { useSelectedGiftBoxStore } from "@/stores/bundle/useStore";
+import { DetailGiftBoxProps } from "@/types/components/types";
+
 import CarouselNavigator from "../common/CarouselNavigator";
 import ImageCarouselButton from "../common/ImageCarouselButton";
 import {
@@ -11,8 +14,6 @@ import {
   CarouselContent,
   CarouselItem,
 } from "../ui/carousel";
-import { useSelectedGiftBoxStore } from "@/stores/bundle/useStore";
-import { DetailGiftBoxProps } from "@/types/components/types";
 
 import AnswerCompleteChip from "./AnswerCompleteChip";
 import ImageCarouselViewer from "./ImageCarouselViewer";

--- a/src/components/bundle/SelectedBundle.tsx
+++ b/src/components/bundle/SelectedBundle.tsx
@@ -3,9 +3,10 @@
 import Image from "next/image";
 import { useEffect, useState } from "react";
 
-import Loading from "../common/Loading";
 import { BUNDLE_IMAGE_PATHS } from "@/constants/constants";
 import { useSelectedBagStore } from "@/stores/bundle/useStore";
+
+import Loading from "../common/Loading";
 
 const SelectedBundle = () => {
   const { selectedBagIndex } = useSelectedBagStore();

--- a/src/components/bundle/add/BundleDrawer.tsx
+++ b/src/components/bundle/add/BundleDrawer.tsx
@@ -1,5 +1,9 @@
 import Link from "next/link";
 
+import { Button } from "@/components/ui/button";
+import { useEditBoxStore } from "@/stores/gift-upload/useStore";
+import { BundleDrawerProps } from "@/types/components/types";
+
 import Card from "../../common/Card";
 import { Icon } from "../../common/Icon";
 import LinkButton from "../../common/LinkButton";
@@ -9,12 +13,8 @@ import {
   DrawerHeader,
   DrawerTitle,
 } from "../../ui/drawer";
-import { Button } from "@/components/ui/button";
-import { useEditBoxStore } from "@/stores/gift-upload/useStore";
 
 import CloseIcon from "/public/icons/close_black.svg";
-
-import { BundleDrawerProps } from "@/types/components/types";
 
 const BundleDrawer = ({
   box,

--- a/src/components/bundle/add/GiftList.tsx
+++ b/src/components/bundle/add/GiftList.tsx
@@ -2,7 +2,6 @@ import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
-import { Drawer, DrawerTrigger } from "../../ui/drawer";
 import {
   Tooltip,
   TooltipContent,
@@ -17,6 +16,8 @@ import {
 import { toast } from "@/hooks/use-toast";
 import { useGiftStore } from "@/stores/gift-upload/useStore";
 import { GiftBox } from "@/types/bundle/types";
+
+import { Drawer, DrawerTrigger } from "../../ui/drawer";
 
 import BundleDrawer from "./BundleDrawer";
 import CustomTooltipArrow from "./CustomTooltipArrow";

--- a/src/components/bundle/add/GiftThumbnailList.tsx
+++ b/src/components/bundle/add/GiftThumbnailList.tsx
@@ -7,12 +7,13 @@ import TrashIcon from "/public/icons/trash.svg";
 
 import Card from "@/components/common/Card";
 import { Icon } from "@/components/common/Icon";
+
+import DeleteBundleDrawer from "./DeleteBundleDrawer";
+
 import { Button } from "@/components/ui/button";
 import { Drawer } from "@/components/ui/drawer";
 import { useDeleteGiftBox } from "@/hooks/bundle/add/useDeleteGiftBox";
 import { useEditBoxStore, useGiftStore } from "@/stores/gift-upload/useStore";
-
-import DeleteBundleDrawer from "./DeleteBundleDrawer";
 
 const GiftThumbnailList = () => {
   const { giftBoxes } = useGiftStore();

--- a/src/components/gift-upload/ChipList.tsx
+++ b/src/components/gift-upload/ChipList.tsx
@@ -1,5 +1,6 @@
-import Chip from "../common/Chip";
 import { ChipListProps } from "@/types/components/types";
+
+import Chip from "../common/Chip";
 
 const ChipList = ({
   chipText,

--- a/src/components/gift-upload/CustomTextArea.tsx
+++ b/src/components/gift-upload/CustomTextArea.tsx
@@ -1,5 +1,6 @@
-import { Textarea } from "../ui/textarea";
 import { CustomTextAreaProps } from "@/types/components/types";
+
+import { Textarea } from "../ui/textarea";
 
 const CustomTextArea = ({
   placeholder,

--- a/src/components/gift-upload/GiftForm.tsx
+++ b/src/components/gift-upload/GiftForm.tsx
@@ -3,9 +3,6 @@
 import { useSearchParams, useRouter } from "next/navigation";
 import { useEffect, useState, useMemo } from "react";
 
-import CharacterCountInput from "../common/CharacterCountInput";
-import ErrorMessage from "../common/ErrorMessage";
-import { Button } from "../ui/button";
 import { GIFT_NAME_MAX_LENGTH, IMAGE_MAX_SIZE_MB } from "@/constants/constants";
 import { useUploadImageMutation } from "@/queries/useUploadImageMutation";
 import {
@@ -16,6 +13,10 @@ import {
 } from "@/stores/gift-upload/useStore";
 import { ImageItem } from "@/types/gift-upload/types";
 import { linkRegex } from "@/utils/giftBoxUtils";
+
+import CharacterCountInput from "../common/CharacterCountInput";
+import ErrorMessage from "../common/ErrorMessage";
+import { Button } from "../ui/button";
 
 import InputLink from "./InputLink";
 import InputReason from "./InputReason";

--- a/src/components/gift-upload/ImageCard.tsx
+++ b/src/components/gift-upload/ImageCard.tsx
@@ -1,9 +1,10 @@
 import Image from "next/image";
 import React from "react";
 
+import { ImageCardProps } from "@/types/components/types";
+
 import EraseIcon from "../../../public/icons/erase.svg";
 import { Icon } from "../common/Icon";
-import { ImageCardProps } from "@/types/components/types";
 
 const ImageCard = ({
   src,

--- a/src/components/gift-upload/InputLink.tsx
+++ b/src/components/gift-upload/InputLink.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { Input } from "../ui/input";
 import { InputLinkProps } from "@/types/components/types";
+
+import { Input } from "../ui/input";
 
 const InputLink = ({ value = "", onChange }: InputLinkProps) => {
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/components/gift-upload/InputReason.tsx
+++ b/src/components/gift-upload/InputReason.tsx
@@ -3,7 +3,6 @@
 import Image from "next/image";
 import { useState, useEffect } from "react";
 
-import GiftIcon from "../../../public/img/gift_letter_square.svg";
 import {
   GIFT_SELECT_REASON_MAX_LENGTH,
   REASON_CHIP_MESSAGES,
@@ -15,6 +14,8 @@ import {
   useTagIndexStore,
 } from "@/stores/gift-upload/useStore";
 import { InputReasonProps } from "@/types/components/types";
+
+import GiftIcon from "../../../public/img/gift_letter_square.svg";
 
 import ChipList from "./ChipList";
 import CustomTextArea from "./CustomTextArea";

--- a/src/components/gift-upload/UploadImageList.tsx
+++ b/src/components/gift-upload/UploadImageList.tsx
@@ -8,7 +8,6 @@ import {
 } from "@dnd-kit/sortable";
 import Image from "next/image";
 
-import ImageIcon from "../../../public/icons/image_medium.svg";
 import {
   GIFT_IMAGE_MAX_AMOUNT,
   IMAGE_EXTENSIONS,
@@ -16,6 +15,8 @@ import {
 } from "@/constants/constants";
 import { UploadImageListProps } from "@/types/components/types";
 import { ImageItem } from "@/types/gift-upload/types";
+
+import ImageIcon from "../../../public/icons/image_medium.svg";
 
 import ImageCard from "./ImageCard";
 import SortableImageWrapper from "./SortableImageWrapper";

--- a/src/components/myBundle/MyBundleCard.tsx
+++ b/src/components/myBundle/MyBundleCard.tsx
@@ -5,6 +5,7 @@ import EraseIcon from "/public/icons/erase.svg";
 
 import { Icon } from "../common/Icon";
 import { DrawerTrigger } from "../ui/drawer";
+
 import { DESIGN_TYPE_MAP } from "@/constants/constants";
 import { MyBundleCardProps } from "@/types/components/types";
 

--- a/src/queries/useMyBundleDetailQuery.ts
+++ b/src/queries/useMyBundleDetailQuery.ts
@@ -4,7 +4,7 @@ import { getMyBundleDetail } from "@/api/my-bundle/api";
 
 export const useMyBundleDetailQuery = (id: number) => {
   return useQuery({
-    queryKey: ["bundleDetail"],
+    queryKey: ["bundleDetail", id],
     queryFn: () => getMyBundleDetail(id),
   });
 };

--- a/src/types/bundle/types.ts
+++ b/src/types/bundle/types.ts
@@ -1,6 +1,7 @@
+import { CarouselApi } from "@/components/ui/carousel";
+
 import { CharacterKey } from "../constants/types";
 import { FilledGift } from "../my-bundles/types";
-import { CarouselApi } from "@/components/ui/carousel";
 
 export interface GiftBox {
   name: string;


### PR DESCRIPTION
### ⚾️ Related Issues

- close #254 

### 📝 Task Details

- 현재 보따리 상세 페이지의 `보따리 1 상세페이지 -> 목록으로 돌아감 -> 보따리 2 상세페이지 ` 과정에서 보따리 1의 정보가 아주 잠깐 보였다가 보따리2로 바뀌는 버그를 해결했습니다. 위쪽 동영상이 수정 전, 아래쪽 동영상이 수정 후(network 설정 fast 4g)입니다. 8ce70a70ab6646aa7ae95504fdd3753570fef894

https://github.com/user-attachments/assets/e16bc323-0075-4413-bc57-af8d2c8024fc

https://github.com/user-attachments/assets/f3509e21-0740-43bf-9b6d-e7903a9f6f30


<br/>
<br/>

- eslint import 설정 해두셨던게 적용이 안된 파일들이 있어 일괄적으로 적용처리했습니다! [fe9050d](https://github.com/dnd-side-project/dnd-12th-5-frontend/pull/255/commits/fe9050d86e5d534ffd3c980b13ee404b4ac482bd)


<br/>
<br/>

- open graph title, image, description 적용했습니다! [695475f](https://github.com/dnd-side-project/dnd-12th-5-frontend/pull/255/commits/695475f9cc9b4d49ab8b13031e34ebd57cb015ab)
<img width="270" alt="스크린샷 2025-05-14 오후 3 49 39" src="https://github.com/user-attachments/assets/1b188d85-1901-4cc1-81a9-09b825a6037d" />


### 📂 References

- screenshots, GIFs, etc.

### 💕 Review Requirements

- Please fill out your review request.
